### PR TITLE
Loosen dependency on rails

### DIFF
--- a/manageiq-api-common.gemspec
+++ b/manageiq-api-common.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "acts_as_tenant"
   spec.add_runtime_dependency "manageiq-password", "~>0.1"
   spec.add_runtime_dependency "pg", "> 0"
-  spec.add_runtime_dependency "rails", "~> 5.2.2"
+  spec.add_runtime_dependency "rails", ">= 5.2.1.1", "~> 5.2"
 
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Each application that includes this should specify its specific version of rails if necessary.