### PR TITLE
Maximums and minimums for limit and offset

### DIFF
--- a/lib/manageiq/api/common/paginated_response.rb
+++ b/lib/manageiq/api/common/paginated_response.rb
@@ -7,7 +7,7 @@ module ManageIQ
         def initialize(base_query:, request:, limit: nil, offset: nil)
           @base_query = base_query
           @request    = request
-          @limit      = (limit || 100).to_i
+          @limit      = (limit || 100).to_i.clamp(1, 1000)
           @offset     = (offset || 0).to_i
         end
 

--- a/lib/manageiq/api/common/paginated_response.rb
+++ b/lib/manageiq/api/common/paginated_response.rb
@@ -8,7 +8,7 @@ module ManageIQ
           @base_query = base_query
           @request    = request
           @limit      = (limit || 100).to_i.clamp(1, 1000)
-          @offset     = (offset || 0).to_i
+          @offset     = (offset || 0).to_i.clamp(0, Float::INFINITY)
         end
 
         def response

--- a/spec/lib/manageiq/api/common/paginated_response_spec.rb
+++ b/spec/lib/manageiq/api/common/paginated_response_spec.rb
@@ -13,6 +13,16 @@ describe ManageIQ::API::Common::PaginatedResponse do
     end
   end
 
+  context "values of offset" do
+    it "unspecified defaults to 0" do
+      expect(described_class.new(base_query: nil, request: nil).offset).to eq(0)
+    end
+
+    it "minimum is 0" do
+      expect(described_class.new(base_query: nil, request: nil, offset: -100).offset).to eq(0)
+    end
+  end
+
   context "private links methods" do
     let(:base_query) { double("AR:Clause", :count => count) }
     let(:request) { double("Request", :original_url => "http://example.com/resource?param1=true&limit=#{limit}") }

--- a/spec/lib/manageiq/api/common/paginated_response_spec.rb
+++ b/spec/lib/manageiq/api/common/paginated_response_spec.rb
@@ -1,4 +1,18 @@
 describe ManageIQ::API::Common::PaginatedResponse do
+  context "values of limit" do
+    it "unspecified defaults to 100" do
+      expect(described_class.new(base_query: nil, request: nil).limit).to eq(100)
+    end
+
+    it "minimum is 1" do
+      expect(described_class.new(base_query: nil, request: nil, limit: 0).limit).to eq(1)
+    end
+
+    it "maximum is 1000" do
+      expect(described_class.new(base_query: nil, request: nil, limit: 1_000_000).limit).to eq(1_000)
+    end
+  end
+
   context "private links methods" do
     let(:base_query) { double("AR:Clause", :count => count) }
     let(:request) { double("Request", :original_url => "http://example.com/resource?param1=true&limit=#{limit}") }


### PR DESCRIPTION
Limit:
- Less than 1 doesn't make sense
- More than 1000 (guess) may cause server problems (timeouts / lots of memory used)

Offset:
- Negative numbers don't make sense