### PR TITLE
Add a prefix to the metrics collector

### DIFF
--- a/lib/manageiq/api/common/metrics.rb
+++ b/lib/manageiq/api/common/metrics.rb
@@ -2,11 +2,11 @@ module ManageIQ
   module API
     module Common
       class Metrics
-        def self.activate(config)
+        def self.activate(config, prefix)
           require 'prometheus/middleware/collector'
           require 'prometheus/middleware/exporter'
 
-          config.middleware.use(Prometheus::Middleware::Collector)
+          config.middleware.use(Prometheus::Middleware::Collector, :metrics_prefix => prefix)
           config.middleware.use(Prometheus::Middleware::Exporter)
         end
       end


### PR DESCRIPTION
This will make it easier to select metrics from different
services in prometheus after they are collected.