### PR TITLE
Add common header utility

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'rails/all'
 require "bundler/setup"
 require "manageiq/api/common"
 

--- a/bin/console
+++ b/bin/console
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require 'rails/all'
 require "bundler/setup"
 require "manageiq/api/common"
 

--- a/lib/manageiq/api/common.rb
+++ b/lib/manageiq/api/common.rb
@@ -1,8 +1,8 @@
 require "manageiq/api/common/engine"
+require "manageiq/api/common/headers"
 require "manageiq/api/common/inflections"
 require "manageiq/api/common/logging"
 require "manageiq/api/common/metrics"
-require "manageiq/api/common/headers"
 
 module ManageIQ
   module API

--- a/lib/manageiq/api/common.rb
+++ b/lib/manageiq/api/common.rb
@@ -2,6 +2,7 @@ require "manageiq/api/common/engine"
 require "manageiq/api/common/inflections"
 require "manageiq/api/common/logging"
 require "manageiq/api/common/metrics"
+require "manageiq/api/common/headers"
 
 module ManageIQ
   module API

--- a/lib/manageiq/api/common/headers.rb
+++ b/lib/manageiq/api/common/headers.rb
@@ -1,42 +1,19 @@
-module HeaderScope
-  thread_mattr_accessor :current
-end
-
 module ManageIQ
   module API
     module Common
       module Headers
-
         def self.current=(val)
           validate_headers(val)
-          HeaderScope.current = val
+          Thread.current[:attr_current_headers] = val
         end
 
         def self.current
-          HeaderScope.current
+          Thread.current[:attr_current_headers]
         end
 
-        def self.decode(headers, key)
-          validate_headers(headers)
-          val = headers.instance_variable_get(:@req).stringify_keys
-          JSON.parse(Base64.decode64(val[key]))
-        end
-
-        def self.encode(val, key)
-          if val.is_a?(Hash)
-            hashed = val.stringify_keys
-            Base64.strict_encode64(hashed[key].to_json)
-          else
-            raise StandardError, "Must be a Hash"
-          end
-        end
-
-        def self.validate_headers(val)
-          if val.is_a?(ActionDispatch::Http::Headers)
-            true
-          else
-            raise StandardError, 'Not an ActionDispatch::Http::Headers Class'
-          end
+        private_class_method def self.validate_headers(val)
+          raise ArgumentError, 'Not an ActionDispatch::Http::Headers Class' unless val.is_a?(ActionDispatch::Http::Headers)
+          true
         end
       end
     end

--- a/lib/manageiq/api/common/headers.rb
+++ b/lib/manageiq/api/common/headers.rb
@@ -1,0 +1,41 @@
+module HeaderScope
+  thread_mattr_accessor :current
+end
+
+module ManageIQ
+  module API
+    module Common
+      module Headers
+
+        def self.current=(val)
+          validate_headers(val)
+          HeaderScope.current = val
+        end
+
+        def self.current
+          HeaderScope.current
+        end
+
+        def self.decode(key)
+          header = HeaderScope.current || nil
+          if header
+            val = header.instance_variable_get(:@req)
+            JSON.parse(Base64.decode64(val[key]))
+          end
+        end
+
+        def self.encode(val, key)
+          Base64.strict_encode64(val[key].to_json)
+        end
+
+        def self.validate_headers(val)
+          if val.is_a?(ActionDispatch::Http::Headers)
+            return
+          else
+            raise StandardError, 'Not a Header Class'
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/manageiq/api/common/headers_spec.rb
+++ b/spec/lib/manageiq/api/common/headers_spec.rb
@@ -1,0 +1,33 @@
+describe ManageIQ::API::Common::Headers do
+  let(:header_good) { ActionDispatch::Http::Headers.new({:blah => 'blah'}) }
+  let(:header_bad)  { {:blah => 'blah' } }
+  # Encoded string: { 'identity' => { 'is_org_admin':true, 'org_id':111 } }
+  let(:encoded_key) { { 'x-rh-identity': 'eyJpZGVudGl0eSI6eyJpc19vcmdfYWRtaW4iOnRydWUsIm9yZ19pZCI6MTExfX0=' } }
+  context "set current headers" do
+    it 'sets if the class is correct' do
+      expect(ManageIQ::API::Common::Headers.current = header_good).to be_a(ActionDispatch::Http::Headers)
+    end
+
+    it 'raises an exception if the class is incorrect' do
+      expect { ManageIQ::API::Common::Headers.current = header_bad }.to raise_exception(StandardError)
+    end
+  end
+
+  describe "#{described_class}#decode" do
+    it "returns a hash representation of a Base64 encoded key" do
+      header = ActionDispatch::Http::Headers.new(encoded_key)
+      identity = described_class.decode(header, 'x-rh-identity')
+      expect(identity).to be_a Hash
+      expect(identity['identity']['is_org_admin']).to be_truthy
+    end
+  end
+
+  describe "#{described_class}#encode" do
+    it "returns a Base64 representation of a hash key" do
+      headers = { 'x-auth-identity' => { 'identity' => { 'is_org_admin' => false } } }
+      encoded = described_class.encode(headers, 'x-auth-identity')
+      expect(encoded).to be_a String
+      expect(encoded).to eq "eyJpZGVudGl0eSI6eyJpc19vcmdfYWRtaW4iOmZhbHNlfX0="
+    end
+  end
+end

--- a/spec/lib/manageiq/api/common/headers_spec.rb
+++ b/spec/lib/manageiq/api/common/headers_spec.rb
@@ -1,33 +1,13 @@
 describe ManageIQ::API::Common::Headers do
   let(:header_good) { ActionDispatch::Http::Headers.new({:blah => 'blah'}) }
   let(:header_bad)  { {:blah => 'blah' } }
-  # Encoded string: { 'identity' => { 'is_org_admin':true, 'org_id':111 } }
-  let(:encoded_key) { { 'x-rh-identity': 'eyJpZGVudGl0eSI6eyJpc19vcmdfYWRtaW4iOnRydWUsIm9yZ19pZCI6MTExfX0=' } }
   context "set current headers" do
     it 'sets if the class is correct' do
       expect(ManageIQ::API::Common::Headers.current = header_good).to be_a(ActionDispatch::Http::Headers)
     end
 
     it 'raises an exception if the class is incorrect' do
-      expect { ManageIQ::API::Common::Headers.current = header_bad }.to raise_exception(StandardError)
-    end
-  end
-
-  describe "#{described_class}#decode" do
-    it "returns a hash representation of a Base64 encoded key" do
-      header = ActionDispatch::Http::Headers.new(encoded_key)
-      identity = described_class.decode(header, 'x-rh-identity')
-      expect(identity).to be_a Hash
-      expect(identity['identity']['is_org_admin']).to be_truthy
-    end
-  end
-
-  describe "#{described_class}#encode" do
-    it "returns a Base64 representation of a hash key" do
-      headers = { 'x-auth-identity' => { 'identity' => { 'is_org_admin' => false } } }
-      encoded = described_class.encode(headers, 'x-auth-identity')
-      expect(encoded).to be_a String
-      expect(encoded).to eq "eyJpZGVudGl0eSI6eyJpc19vcmdfYWRtaW4iOmZhbHNlfX0="
+      expect { ManageIQ::API::Common::Headers.current = header_bad }.to raise_exception(ArgumentError)
     end
   end
 end


### PR DESCRIPTION
1. Sets / Get a thread safe version of any Rails header `ManageIQ::API::Common::Headers.current = headers` makes use of  `Thread.current[:attr_current_headers]`

2. Provides simple validation forcing a saved header using the Rails `ActionDispatch::Http::Headers` type.


Addresses this #29 