### PR TITLE
Pagination fixes

### DIFF
--- a/lib/manageiq/api/common/paginated_response.rb
+++ b/lib/manageiq/api/common/paginated_response.rb
@@ -31,7 +31,7 @@ module ManageIQ
             "last"  => link_to_last,
             "prev"  => link_to_prev,
             "next"  => link_to_next,
-          }
+          }.compact
         end
 
         def link_to_first

--- a/lib/manageiq/api/common/paginated_response.rb
+++ b/lib/manageiq/api/common/paginated_response.rb
@@ -56,9 +56,7 @@ module ManageIQ
         end
 
         def link_with_new_offset(offset)
-          request_uri.dup.tap do |u|
-            u.query = query_hash_merge("offset" => offset.to_s)
-          end.to_s
+          URI::Generic.build(:path => request_uri.path, :query => query_hash_merge("offset" => offset.to_s)).to_s
         end
 
         def query_hash_merge(new_hash)

--- a/spec/lib/manageiq/api/common/paginated_response_spec.rb
+++ b/spec/lib/manageiq/api/common/paginated_response_spec.rb
@@ -39,7 +39,7 @@ describe ManageIQ::API::Common::PaginatedResponse do
 
       it "first page" do
         expect(described_class.new(base_query: base_query, request: request, limit: 2).send(:links_hash)).to eq(
-          "first" => first_url, "last" => last_url, "next" => url_with_offset(2), "prev" => nil
+          "first" => first_url, "last" => last_url, "next" => url_with_offset(2)
         )
       end
 
@@ -51,7 +51,7 @@ describe ManageIQ::API::Common::PaginatedResponse do
 
       it "third page" do
         expect(described_class.new(base_query: base_query, request: request, limit: 2, offset: 4).send(:links_hash)).to eq(
-          "first" => first_url, "last" => last_url, "next" => nil, "prev" => url_with_offset(2)
+          "first" => first_url, "last" => last_url, "prev" => url_with_offset(2)
         )
       end
     end
@@ -64,7 +64,7 @@ describe ManageIQ::API::Common::PaginatedResponse do
 
       it "first page" do
         expect(described_class.new(base_query: base_query, request: request, limit: 10).send(:links_hash)).to eq(
-          "first" => first_url, "last" => last_url, "next" => url_with_offset(10), "prev" => nil
+          "first" => first_url, "last" => last_url, "next" => url_with_offset(10)
         )
       end
 
@@ -82,7 +82,7 @@ describe ManageIQ::API::Common::PaginatedResponse do
 
       it "fourth page" do
         expect(described_class.new(base_query: base_query, request: request, limit: 10, offset: 30).send(:links_hash)).to eq(
-          "first" => first_url, "last" => last_url, "next" => nil, "prev" => url_with_offset(20)
+          "first" => first_url, "last" => last_url, "prev" => url_with_offset(20)
         )
       end
     end

--- a/spec/lib/manageiq/api/common/paginated_response_spec.rb
+++ b/spec/lib/manageiq/api/common/paginated_response_spec.rb
@@ -28,7 +28,7 @@ describe ManageIQ::API::Common::PaginatedResponse do
     let(:request) { double("Request", :original_url => "http://example.com/resource?param1=true&limit=#{limit}") }
 
     def url_with_offset(offset)
-      "http://example.com/resource?limit=#{limit}&offset=#{offset}&param1=true"
+      "/resource?limit=#{limit}&offset=#{offset}&param1=true"
     end
 
     context "number of records evenly divisible by limit" do


### PR DESCRIPTION
- Return relative links for pagination
- Only return link references that have values in order to be swagger compliant