### PR TITLE
Add limit and offset to PaginatedResponse meta.

### DIFF
--- a/lib/manageiq/api/common/paginated_response.rb
+++ b/lib/manageiq/api/common/paginated_response.rb
@@ -22,7 +22,7 @@ module ManageIQ
         private
 
         def metadata_hash
-          @metadata_hash ||= {"count" => count}
+          @metadata_hash ||= {"count" => count, "limit" => limit, "offset" => offset}
         end
 
         def links_hash

--- a/spec/lib/manageiq/api/common/paginated_response_spec.rb
+++ b/spec/lib/manageiq/api/common/paginated_response_spec.rb
@@ -23,6 +23,28 @@ describe ManageIQ::API::Common::PaginatedResponse do
     end
   end
 
+  context "metainformation" do
+    let(:base_query) { double("AR:Clause", :count => count) }
+    let(:request) { double("Request", :original_url => "http://example.com/resource?param1=true&limit=#{limit}") }
+    let(:count) { 6 }
+    let(:limit) { 2 }
+    let(:offset) { 2 }
+
+    context "contains correct count, limit and offset" do
+      it "first page" do
+        expect(described_class.new(base_query: base_query, request: request, limit: limit).send(:metadata_hash)).to eq(
+          "count" => count, "limit" => limit, "offset" => 0
+        )
+      end
+
+      it "second page" do
+        expect(described_class.new(base_query: base_query, request: request, limit: limit, offset: offset).send(:metadata_hash)).to eq(
+          "count" => count, "limit" => limit, "offset" => offset
+        )
+      end
+    end
+  end
+
   context "private links methods" do
     let(:base_query) { double("AR:Clause", :count => count) }
     let(:request) { double("Request", :original_url => "http://example.com/resource?param1=true&limit=#{limit}") }


### PR DESCRIPTION
It's convenient to have all the paging metainformation available in every paginated responses.

Adding the `limit` and `offset` fields.

![meta 2019-03-01_13-01](https://user-images.githubusercontent.com/51095/53636981-365b0480-3c22-11e9-9977-13be348a40a6.png)

Ping @Hyperkid123 