### PR TITLE
Refactor user accessors

### DIFF
--- a/lib/manageiq/api/common/user.rb
+++ b/lib/manageiq/api/common/user.rb
@@ -4,36 +4,19 @@ module ManageIQ
       class User
         IDENTITY_KEY = 'x-rh-identity'.freeze
 
-        def username
-          validate_and_return(__method__)
-        end
-
-        def email
-          validate_and_return(__method__)
-        end
-
-        def first_name
-          validate_and_return(__method__)
-        end
-
-        def last_name
-          validate_and_return(__method__)
-        end
-
-        def is_active?
-          validate_and_return(:is_active)
-        end
-
-        def is_org_admin?
-          validate_and_return(:is_org_admin)
-        end
-
-        def is_internal?
-          validate_and_return(:is_internal)
-        end
-
-        def locale
-          validate_and_return(__method__)
+        %w[
+          username
+          email
+          first_name
+          is_active
+          is_org_admin
+          is_internal
+          last_name
+          locale
+        ].each do |m|
+          define_method(m.start_with?("is_") ? "#{m[3..-1]}?" : m) do
+            find_user_key(m)
+          end
         end
 
         def tenant
@@ -48,12 +31,8 @@ module ManageIQ
           JSON.parse(Base64.decode64(user_hash))
         end
 
-        def validate_and_return(key)
-          find_user_key(decode, key)
-        end
-
-        def find_user_key(hash, key)
-          result = hash.dig('identity', 'user', key.to_s)
+        def find_user_key(key)
+          result = decode.dig('identity', 'user', key.to_s)
           raise ManageIQ::API::Common::HeaderIdentityError, "#{key} doesn't exist" if result.nil?
           result
         end

--- a/spec/lib/manageiq/api/common/user_spec.rb
+++ b/spec/lib/manageiq/api/common/user_spec.rb
@@ -17,7 +17,7 @@ describe ManageIQ::API::Common::User do
   end
 
   context "user getter methods" do
-    let(:user_keys)   { %w(username email first_name last_name is_active? is_org_admin? is_internal? locale tenant) }
+    let(:user_keys)   { %w(username email first_name last_name active? org_admin? internal? locale tenant) }
     let(:user_values) { ['jdoe', 'jdoe@acme.com', 'John', 'Doe', true, false, false, 'en_US', '0369233'] }
     let(:bad_user)    { %w(fred barney type) }
     let(:user)        { ManageIQ::API::Common::Request.current.user }


### PR DESCRIPTION
@syncrou What do you think?

This trims up the repetition, makes find_user_key work on decode directly the same way find_tenant does, and changes the `?` accessors to not have the leading `is_`