### PR TITLE
Rename HeadersNotSet to RequestNotSet

### DIFF
--- a/lib/manageiq/api/common/exceptions.rb
+++ b/lib/manageiq/api/common/exceptions.rb
@@ -1,7 +1,6 @@
 module ManageIQ
   module API
     module Common
-      class HeadersNotSet < ArgumentError; end
       class HeaderIdentityError < StandardError; end
     end
   end

--- a/lib/manageiq/api/common/request.rb
+++ b/lib/manageiq/api/common/request.rb
@@ -1,11 +1,21 @@
 module ManageIQ
   module API
     module Common
+      class RequestNotSet < ArgumentError
+        def initialize
+          super("Current request has not been set")
+        end
+      end
+
       class Request
         FORWARDABLE_HEADER_KEYS = %w(X-Request-ID x-rh-identity).freeze
 
         def self.current
           Thread.current[:current_request]
+        end
+
+        def self.current!
+          current || raise(RequestNotSet)
         end
 
         def self.current=(request)
@@ -31,8 +41,7 @@ module ManageIQ
         end
 
         def self.current_forwardable
-          raise ManageIQ::API::Common::HeadersNotSet, "Current headers have not been set" unless current
-          current.forwardable
+          current!.forwardable
         end
 
         attr_reader :headers, :original_url

--- a/lib/manageiq/api/common/user.rb
+++ b/lib/manageiq/api/common/user.rb
@@ -26,7 +26,7 @@ module ManageIQ
         private
 
         def decode
-          hashed = ManageIQ::API::Common::Request.current.to_h
+          hashed = Request.current!.to_h
           user_hash = hashed[:headers][IDENTITY_KEY]
           JSON.parse(Base64.decode64(user_hash))
         end

--- a/spec/lib/manageiq/api/common/request_spec.rb
+++ b/spec/lib/manageiq/api/common/request_spec.rb
@@ -113,6 +113,20 @@ describe ManageIQ::API::Common::Request do
     end
   end
 
+  describe ".current!" do
+    it "when the request is set" do
+      described_class.with_request(request_good) do |instance|
+        expect(described_class.current!).to eq instance
+      end
+    end
+
+    it "when the request is not set" do
+      expect do
+        described_class.current!
+      end.to raise_exception(ManageIQ::API::Common::RequestNotSet)
+    end
+  end
+
   describe ".current_forwardable" do
     it "only includes expected headers" do
       described_class.with_request(request_good) do
@@ -125,7 +139,7 @@ describe ManageIQ::API::Common::Request do
     it "raises exception when headers not set" do
       expect do
         described_class.current_forwardable
-      end.to raise_exception(ManageIQ::API::Common::HeadersNotSet)
+      end.to raise_exception(ManageIQ::API::Common::RequestNotSet)
     end
   end
 end


### PR DESCRIPTION
Additionally add a helper method Request.current! that raises when then
Request.current is not set.

@syncrou Please review.  If there is any calling code actually catching HeadersNotSet, it would have to be changed for this PR.  If needed I can add a temporary alias of the constant.
cc @bdunne 