### PR TITLE
Add accessors for headers

### DIFF
--- a/lib/manageiq/api/common.rb
+++ b/lib/manageiq/api/common.rb
@@ -1,14 +1,6 @@
 require "manageiq/api/common/engine"
-require "manageiq/api/common/exceptions"
 require "manageiq/api/common/inflections"
 require "manageiq/api/common/logging"
 require "manageiq/api/common/metrics"
 require "manageiq/api/common/request"
 require "manageiq/api/common/user"
-
-module ManageIQ
-  module API
-    module Common
-    end
-  end
-end

--- a/lib/manageiq/api/common/exceptions.rb
+++ b/lib/manageiq/api/common/exceptions.rb
@@ -1,7 +1,0 @@
-module ManageIQ
-  module API
-    module Common
-      class HeaderIdentityError < StandardError; end
-    end
-  end
-end

--- a/spec/lib/manageiq/api/common/request_spec.rb
+++ b/spec/lib/manageiq/api/common/request_spec.rb
@@ -21,7 +21,7 @@ describe ManageIQ::API::Common::Request do
   let(:forwardable_good) do
     {
       'x-rh-identity' => encoded_user_hash,
-      'X-Request-ID'  => "01234567-89ab-cdef-0123-456789abcde",
+      'x-request-id'  => "01234567-89ab-cdef-0123-456789abcde",
     }
   end
 
@@ -53,6 +53,43 @@ describe ManageIQ::API::Common::Request do
 
     it "#to_h" do
       expect(@instance.to_h).to eq(:headers => forwardable_good, :original_url => "https://example.com")
+    end
+
+    it "#user" do
+      expect(@instance.user).to be_a(ManageIQ::API::Common::User)
+    end
+
+    it "#request_id" do
+      expect(@instance.request_id).to eq "01234567-89ab-cdef-0123-456789abcde"
+    end
+
+    it "#identity" do
+      expect(@instance.identity).to eq default_user_hash
+    end
+
+    it "#to_h" do
+      expect(@instance.to_h).to eq(:headers => forwardable_good, :original_url => "https://example.com")
+    end
+  end
+
+  context "with a bad request" do
+    around do |example|
+      described_class.with_request(request_bad) do |instance|
+        @instance = instance
+        example.call
+      end
+    end
+
+    it "#user" do
+      expect { @instance.user }.to raise_exception(KeyError, 'x-rh-identity')
+    end
+
+    it "#identity" do
+      expect { @instance.identity }.to raise_exception(KeyError, 'x-rh-identity')
+    end
+
+    it "#request_id" do
+      expect { @instance.request_id }.to raise_exception(KeyError, 'x-request-id')
     end
   end
 

--- a/spec/lib/manageiq/api/common/user_spec.rb
+++ b/spec/lib/manageiq/api/common/user_spec.rb
@@ -56,7 +56,7 @@ describe ManageIQ::API::Common::User do
 
   context "user bad hash" do
     it "raises an exception when a user method does not respond" do
-      expect { ManageIQ::API::Common::Request.current.user.last_name }.to raise_exception(ManageIQ::API::Common::HeaderIdentityError)
+      expect { ManageIQ::API::Common::Request.current.user.last_name }.to raise_exception(ManageIQ::API::Common::IdentityError)
     end
   end
 end


### PR DESCRIPTION
This PR adds accessors for specific header keys in the Request, and by doing so separates the "header" knowledge from the User class.  That is, the user just gets the identity hash from the request and doesn't have to know it's a header.

@syncrou Please review

Built on #43 so just review the second commit.
Closes #36 

