### PR TITLE
Using the wrong header key for x-rh-insights-request-id

### DIFF
--- a/lib/manageiq/api/common/request.rb
+++ b/lib/manageiq/api/common/request.rb
@@ -8,9 +8,9 @@ module ManageIQ
       end
 
       class Request
-        REQUEST_ID_KEY = "x-request-id".freeze
+        X_RH_INSIGHTS_REQUEST_ID_KEY = "x-rh-insights-request-id".freeze
         IDENTITY_KEY   = 'x-rh-identity'.freeze
-        FORWARDABLE_HEADER_KEYS = [REQUEST_ID_KEY, IDENTITY_KEY].freeze
+        FORWARDABLE_HEADER_KEYS = [X_RH_INSIGHTS_REQUEST_ID_KEY, IDENTITY_KEY].freeze
 
         def self.current
           Thread.current[:current_request]
@@ -54,7 +54,7 @@ module ManageIQ
         end
 
         def request_id
-          headers.fetch(REQUEST_ID_KEY)
+          headers.fetch(X_RH_INSIGHTS_REQUEST_ID_KEY)
         end
 
         def identity

--- a/lib/manageiq/api/common/request.rb
+++ b/lib/manageiq/api/common/request.rb
@@ -8,9 +8,9 @@ module ManageIQ
       end
 
       class Request
-        X_RH_INSIGHTS_REQUEST_ID_KEY = "x-rh-insights-request-id".freeze
+        REQUEST_ID_KEY = "x-rh-insights-request-id".freeze
         IDENTITY_KEY   = 'x-rh-identity'.freeze
-        FORWARDABLE_HEADER_KEYS = [X_RH_INSIGHTS_REQUEST_ID_KEY, IDENTITY_KEY].freeze
+        FORWARDABLE_HEADER_KEYS = [REQUEST_ID_KEY, IDENTITY_KEY].freeze
 
         def self.current
           Thread.current[:current_request]
@@ -54,7 +54,7 @@ module ManageIQ
         end
 
         def request_id
-          headers.fetch(X_RH_INSIGHTS_REQUEST_ID_KEY)
+          headers.fetch(REQUEST_ID_KEY)
         end
 
         def identity

--- a/spec/lib/manageiq/api/common/request_spec.rb
+++ b/spec/lib/manageiq/api/common/request_spec.rb
@@ -20,8 +20,8 @@ describe ManageIQ::API::Common::Request do
 
   let(:forwardable_good) do
     {
-      'x-rh-identity' => encoded_user_hash,
-      'x-request-id'  => "01234567-89ab-cdef-0123-456789abcde",
+      'x-rh-identity'            => encoded_user_hash,
+      'x-rh-insights-request-id' => "01234567-89ab-cdef-0123-456789abcde",
     }
   end
 
@@ -89,7 +89,7 @@ describe ManageIQ::API::Common::Request do
     end
 
     it "#request_id" do
-      expect { @instance.request_id }.to raise_exception(KeyError, 'x-request-id')
+      expect { @instance.request_id }.to raise_exception(KeyError, 'x-rh-insights-request-id')
     end
   end
 


### PR DESCRIPTION
We were incorrectly using x-request-id

The x-request-id comes from rails via this config setting

https://github.com/ManageIQ/catalog-api/blob/daa356d660efc78bcc5d5375a5917fbb463a3f0d/config/environments/production.rb#L48