### PR TITLE
Added support in ManageIQ::API::Common::Request to know about request paths with optional authentication

### DIFF
--- a/lib/manageiq/api/common/request.rb
+++ b/lib/manageiq/api/common/request.rb
@@ -11,6 +11,10 @@ module ManageIQ
         REQUEST_ID_KEY = "x-rh-insights-request-id".freeze
         IDENTITY_KEY   = 'x-rh-identity'.freeze
         FORWARDABLE_HEADER_KEYS = [REQUEST_ID_KEY, IDENTITY_KEY].freeze
+        OPTIONAL_AUTH_PATHS = [
+          %r{\A/api/v[0-9]+(\.[0-9]+)?/openapi.json\z},
+          %r{\A/api/[^/]+/v[0-9]+(\.[0-9]+)?/openapi.json\z}
+        ].freeze
 
         def self.current
           Thread.current[:current_request]
@@ -73,6 +77,15 @@ module ManageIQ
           FORWARDABLE_HEADER_KEYS.each_with_object({}) do |key, hash|
             hash[key] = headers[key] if headers.key?(key)
           end
+        end
+
+        def required_auth?
+          !optional_auth?
+        end
+
+        def optional_auth?
+          uri_path = URI.parse(original_url).path
+          OPTIONAL_AUTH_PATHS.any? { |optional_auth_path_regex| optional_auth_path_regex.match(uri_path) }
         end
 
         private

--- a/spec/lib/manageiq/api/common/request_spec.rb
+++ b/spec/lib/manageiq/api/common/request_spec.rb
@@ -179,4 +179,51 @@ describe ManageIQ::API::Common::Request do
       end.to raise_exception(ManageIQ::API::Common::RequestNotSet)
     end
   end
+
+  describe ".optional_auth? and .required_auth?" do
+    it "handle fully qualified openapi.json path with major version" do
+      described_class.with_request(request_good.merge(
+                                     :original_url => "https://example.com/api/micro-service/v1/openapi.json"
+                                   )) do
+        expect(described_class.current.optional_auth?).to be_truthy
+        expect(described_class.current.required_auth?).to be_falsy
+      end
+    end
+
+    it "handle fully qualified openapi.json path with major and minor version" do
+      described_class.with_request(request_good.merge(
+                                     :original_url => "https://example.com/api/micro-service/v1.0/openapi.json"
+                                   )) do
+        expect(described_class.current.optional_auth?).to be_truthy
+        expect(described_class.current.required_auth?).to be_falsy
+      end
+    end
+
+    it "handle short openapi.json path with major version" do
+      described_class.with_request(request_good.merge(
+                                     :original_url => "https://example.com/api/v1/openapi.json"
+                                   )) do
+        expect(described_class.current.optional_auth?).to be_truthy
+        expect(described_class.current.required_auth?).to be_falsy
+      end
+    end
+
+    it "handle short openapi.json path with major and minor version" do
+      described_class.with_request(request_good.merge(
+                                     :original_url => "https://example.com/api/v1.0/openapi.json"
+                                   )) do
+        expect(described_class.current.optional_auth?).to be_truthy
+        expect(described_class.current.required_auth?).to be_falsy
+      end
+    end
+
+    it "handle normal authenticated paths" do
+      described_class.with_request(request_good.merge(
+                                     :original_url => "https://example.com/api/micro-service/v1.0/collection"
+                                   )) do
+        expect(described_class.current.optional_auth?).to be_falsy
+        expect(described_class.current.required_auth?).to be_truthy
+      end
+    end
+  end
 end


### PR DESCRIPTION

- Exposing optional_auth? and related required_auth?
- The common paths include:
   - /api/.*/v#[.#]/openapi.json (osd deployment)
   - /api/v#[.#]/openapi.json (rails dev env)