### PR TITLE
Raise IdentityError if x-rh-identity doesn't exist on User initialize

### DIFF
--- a/lib/manageiq/api/common/request.rb
+++ b/lib/manageiq/api/common/request.rb
@@ -63,6 +63,8 @@ module ManageIQ
 
         def identity
           @identity ||= JSON.parse(Base64.decode64(headers.fetch(IDENTITY_KEY)))
+        rescue KeyError
+          raise IdentityError, "x-rh-identity not found"
         end
 
         def user

--- a/spec/lib/manageiq/api/common/request_spec.rb
+++ b/spec/lib/manageiq/api/common/request_spec.rb
@@ -81,11 +81,11 @@ describe ManageIQ::API::Common::Request do
     end
 
     it "#user" do
-      expect { @instance.user }.to raise_exception(KeyError, 'x-rh-identity')
+      expect { @instance.user }.to raise_exception(ManageIQ::API::Common::IdentityError, 'x-rh-identity not found')
     end
 
     it "#identity" do
-      expect { @instance.identity }.to raise_exception(KeyError, 'x-rh-identity')
+      expect { @instance.identity }.to raise_exception(ManageIQ::API::Common::IdentityError, 'x-rh-identity not found')
     end
 
     it "#request_id" do


### PR DESCRIPTION
Instead of letting the `KeyError` blow through here and subsequently rescuing for something as generic as KeyError, raise `ManageIQ::API::Common::IdentityError` instead since there isn't an identity to begin with due to the lack of an `x-rh-identity` header. 

On the catalog side we've been rescuing from a `KeyError` for a long time, but this makes much more sense and is more descriptive. It also allows us to change the rails behavior on `ActionController::ParameterMissing` since that is a KeyError itself it was hard to handle it any differently application-wide. 