### PR TITLE
Allow .current= argument to be a ManageIQ::API::Common::Request type

### DIFF
--- a/lib/manageiq/api/common/request.rb
+++ b/lib/manageiq/api/common/request.rb
@@ -31,10 +31,10 @@ module ManageIQ
               new(:headers => request.headers, :original_url => request.original_url)
             when Hash
               new(request)
-            when nil
+            when Request, nil
               request
             else
-              raise ArgumentError, 'Not an ActionDispatch::Http::Headers Class or Hash, or nil'
+              raise ArgumentError, 'Not a ManageIQ::API::Common::Request or ActionDispatch::Request Class, Hash, or nil'
             end
         end
 

--- a/spec/lib/manageiq/api/common/request_spec.rb
+++ b/spec/lib/manageiq/api/common/request_spec.rb
@@ -102,6 +102,15 @@ describe ManageIQ::API::Common::Request do
       end
     end
 
+    it 'with a ManageIQ::API::Common::Request' do
+      common_request = described_class.new(request_good)
+      described_class.with_request(common_request) do |instance|
+        expect(described_class.current).to eq instance
+        expect(instance).to be_a(ManageIQ::API::Common::Request)
+        expect(instance.headers).to be_a(ActionDispatch::Http::Headers)
+      end
+    end
+
     it 'with a specific Hash' do
       described_class.with_request(request_good) do |instance|
         expect(described_class.current).to eq instance


### PR DESCRIPTION
Fix an issue for
https://github.com/ManageIQ/manageiq-api-common/pull/55/files#diff-35dc214cbf96bc055529320b09ba5ee3R46 where we need to restore from saved current which is a type of `ManageIQ::API::Common::Request` if not `nil`, but the setter does not accept this type.