### PR TITLE
Print a warning when no spec dummy database.yml exists

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,13 @@ if ENV['CI']
 end
 
 ENV["RAILS_ENV"] ||= 'test'
+
+unless File.exists?("spec/dummy/config/database.yml")
+  print "\n"
+  puts "WARNING: spec/dummy/config/database.yml is missing, tests cannot continue!"
+  print "\n"
+  exit
+end
 require File.expand_path("../dummy/config/environment", __FILE__)
 
 require 'rspec/rails'


### PR DESCRIPTION
When running tests locally for the common gem, the default warning doesn't reference the path
where the `database.yml` file is missing.
This error message loads from `spec_helper.rb` and stops the specs
unless the file exists. It also references where the `database.yml` file should be placed.