### PR TITLE
Add entitlements

### DIFF
--- a/lib/manageiq/api/common.rb
+++ b/lib/manageiq/api/common.rb
@@ -1,4 +1,5 @@
 require "manageiq/api/common/engine"
+require "manageiq/api/common/entitlement"
 require "manageiq/api/common/error_document"
 require "manageiq/api/common/filter"
 require "manageiq/api/common/inflections"

--- a/lib/manageiq/api/common/entitlement.rb
+++ b/lib/manageiq/api/common/entitlement.rb
@@ -25,7 +25,7 @@ module ManageIQ
 
         def find_entitlement_key(key)
           result = identity.dig('entitlements', key.to_s)
-          #TODO Always force entitlements key
+          # TODO: Always force entitlements key
           return true unless result
           result['is_entitled']
         end

--- a/lib/manageiq/api/common/entitlement.rb
+++ b/lib/manageiq/api/common/entitlement.rb
@@ -1,0 +1,35 @@
+module ManageIQ
+  module API
+    module Common
+      class EntitlementError < StandardError; end
+
+      class Entitlement
+        def initialize(identity)
+          @identity = identity
+        end
+
+        %w[
+          hybrid_cloud
+          insights
+          openshift
+          smart_management
+        ].each do |m|
+          define_method(m) do
+            find_entitlement_key(m)
+          end
+        end
+
+        private
+
+        attr_reader :identity
+
+        def find_entitlement_key(key)
+          result = identity.dig('entitlements', key.to_s)
+          return true unless result
+          #raise EntitlementError, "#{key} doesn't exist" if result.nil?
+          result['is_entitled']
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/api/common/entitlement.rb
+++ b/lib/manageiq/api/common/entitlement.rb
@@ -14,7 +14,7 @@ module ManageIQ
           openshift
           smart_management
         ].each do |m|
-          define_method(m) do
+          define_method("#{m}?") do
             find_entitlement_key(m)
           end
         end
@@ -25,8 +25,8 @@ module ManageIQ
 
         def find_entitlement_key(key)
           result = identity.dig('entitlements', key.to_s)
+          #TODO Always force entitlements key
           return true unless result
-          #raise EntitlementError, "#{key} doesn't exist" if result.nil?
           result['is_entitled']
         end
       end

--- a/lib/manageiq/api/common/request.rb
+++ b/lib/manageiq/api/common/request.rb
@@ -71,6 +71,10 @@ module ManageIQ
           @user ||= User.new(identity)
         end
 
+        def entitlement
+          @entitlement ||= Entitlement.new(identity)
+        end
+
         def to_h
           {:headers => forwardable, :original_url => original_url}
         end

--- a/spec/lib/manageiq/api/common/entitlements_spec.rb
+++ b/spec/lib/manageiq/api/common/entitlements_spec.rb
@@ -9,8 +9,8 @@ describe ManageIQ::API::Common::Entitlement do
   end
 
   context "entitlement getter methods" do
-    let(:entitlement_keys) { %w(insights openshift hybrid_cloud smart_management) }
-    let(:bad_entitlement)  { %w(fred barney type) }
+    let(:entitlement_keys) { %w[insights openshift hybrid_cloud smart_management] }
+    let(:bad_entitlement)  { %w[fred barney type] }
     let(:entitlement)      { ManageIQ::API::Common::Request.current.entitlement }
     let(:other_user)       { default_user_hash }
 

--- a/spec/lib/manageiq/api/common/entitlements_spec.rb
+++ b/spec/lib/manageiq/api/common/entitlements_spec.rb
@@ -1,0 +1,29 @@
+describe ManageIQ::API::Common::Entitlement do
+  let(:encoded) { encoded_user_hash }
+  let(:request_good) do
+    { :headers => { 'x-rh-identity' => encoded }, :original_url => 'whatever' }
+  end
+
+  around do |example|
+    ManageIQ::API::Common::Request.with_request(request_good) { example.call }
+  end
+
+  context "entitlement getter methods" do
+    let(:entitlement_keys) { %w(insights openshift hybrid_cloud smart_management) }
+    let(:bad_entitlement)  { %w(fred barney type) }
+    let(:entitlement)      { ManageIQ::API::Common::Request.current.entitlement }
+    let(:other_user)       { default_user_hash }
+
+    it "returns values for entitlement methods" do
+      entitlement_keys.each do |key|
+        expect(entitlement.respond_to?("#{key}?")).to be_truthy
+      end
+    end
+
+    it "raises an exception for keys that do not exist" do
+      bad_entitlement.each do |key|
+        expect { entitlement.send("#{key}?") }.to raise_exception(NoMethodError)
+      end
+    end
+  end
+end

--- a/spec/support/user_header_spec_helper.rb
+++ b/spec/support/user_header_spec_helper.rb
@@ -1,5 +1,19 @@
 module UserHeaderSpecHelper
   DEFAULT_USER = {
+    "entitlements" => {
+      "hybrid_cloud"      => {
+        "is_entitled" => true
+      },
+      "insights"         => {
+        "is_entitled" => true
+      },
+      "openshift"        => {
+        "is_entitled" => true
+      },
+      "smart_management" => {
+        "is_entitled" => true
+      }
+    },
     "identity" => {
       "account_number" => "0369233",
       "type"           => "User",

--- a/spec/support/user_header_spec_helper.rb
+++ b/spec/support/user_header_spec_helper.rb
@@ -1,7 +1,7 @@
 module UserHeaderSpecHelper
   DEFAULT_USER = {
     "entitlements" => {
-      "hybrid_cloud"      => {
+      "hybrid_cloud"     => {
         "is_entitled" => true
       },
       "insights"         => {


### PR DESCRIPTION
Adds `Entitlement` class allowing services to query current enabled / disabled entitlements on a service.

This PR does _not_ raise the `EntitlementError` even though it is setup inline with the class. Until Entitlements are checked in all services, we are allowing all requests through if the `entitlements` key is not found.
```
  "entitlements": {
    "hybrid_cloud": {
      "is_entitled": true
    },
    "insights": {
      "is_entitled": true
    },
    "openshift": {
      "is_entitled": true
    },
    "smart_management": {
      "is_entitled": true
    }
  }
}
```
Examples:
```
2.4.1 :001 >  ent_hash =  {"entitlements" => {
2.4.1 :002 >           "hybrid_cloud" => {
2.4.1 :003 >               "is_entitled" => true
2.4.1 :004?>           },
2.4.1 :005 >           "insights" => {
2.4.1 :006 >               "is_entitled" => true
2.4.1 :007?>           },
2.4.1 :008 >           "openshift" => {
2.4.1 :009 >               "is_entitled" => true
2.4.1 :010?>           },
2.4.1 :011 >           "smart_management" => {
2.4.1 :012 >               "is_entitled" => true
2.4.1 :013?>           }
2.4.1 :014?>       }
2.4.1 :015?>   }
 => {"entitlements"=>{"hybrid_cloud"=>{"is_entitled"=>true}, "insights"=>{"is_entitled"=>true}, "openshift"=>{"is_entitled"=>true}, "smart_management"=>{"is_entitled"=>true}}}

ents = ManageIQ::API::Common::Entitlement.new(ent_hash)2.4.1 :016 >
2.4.1 :017 > ents = ManageIQ::API::Common::Entitlement.new(ent_hash)
 => #<ManageIQ::API::Common::Entitlement:0x00007ff98c123be8 @identity={"entitlements"=>{"hybrid_cloud"=>{"is_entitled"=>true}, "insights"=>{"is_entitled"=>true}, "openshift"=>{"is_entitled"=>true}, "smart_management"=>{"is_entitled"=>true}}}>
2.4.1 :018 > ents.openshift?
 => true
2.4.1 :019 > ents.hybrid_cloud?
 => true
2.4.1 :020 > ents.smart_management?
 => true
2.4.1 :021 > ents.insights
Traceback (most recent call last):
        1: from (irb):21
NoMethodError (undefined method `insights' for #<ManageIQ::API::Common::Entitlement:0x00007ff98c123be8>)
Did you mean?  insights?
2.4.1 :022 > ents.insights?
=> true
```
