### PR TITLE
If the x-rh-insights-request-id is missing return nil

### DIFF
--- a/lib/manageiq/api/common/request.rb
+++ b/lib/manageiq/api/common/request.rb
@@ -58,7 +58,7 @@ module ManageIQ
         end
 
         def request_id
-          headers.fetch(REQUEST_ID_KEY)
+          headers.fetch(REQUEST_ID_KEY, nil)
         end
 
         def identity

--- a/spec/lib/manageiq/api/common/request_spec.rb
+++ b/spec/lib/manageiq/api/common/request_spec.rb
@@ -89,7 +89,7 @@ describe ManageIQ::API::Common::Request do
     end
 
     it "#request_id" do
-      expect { @instance.request_id }.to raise_exception(KeyError, 'x-rh-insights-request-id')
+      expect(@instance.request_id).to be_nil
     end
   end
 


### PR DESCRIPTION
Currently it validates the request to contain the header key
x-rh-insights-request-id if its missing it raises the KeyError
Suppressing it to return a nil if the key doesn't exist