### PR TITLE
Return Api::Docs to not return content

### DIFF
--- a/lib/manageiq/api/common/open_api/docs/doc_v3.rb
+++ b/lib/manageiq/api/common/open_api/docs/doc_v3.rb
@@ -47,6 +47,10 @@ module ManageIQ
               @content["paths"]
             end
 
+            def to_json(options = nil)
+              content.to_json(options)
+            end
+
             def routes
               @routes ||= begin
                 paths.flat_map do |path, hash|


### PR DESCRIPTION
Don't wrap the OpenApi Doc in a content key

Fixes https://github.com/ManageIQ/manageiq-api-common/issues/64