### PR TITLE
Use the cloud watch logger

### DIFF
--- a/lib/manageiq/api/common/logging.rb
+++ b/lib/manageiq/api/common/logging.rb
@@ -6,7 +6,7 @@ module ManageIQ
           require 'manageiq/loggers'
           config.logger = if Rails.env.production?
                             config.colorize_logging = false
-                            ManageIQ::Loggers::Container.new
+                            ManageIQ::Loggers::CloudWatch.new
                           else
                             ManageIQ::Loggers::Base.new(Rails.root.join("log", "#{Rails.env}.log"))
                           end

--- a/manageiq-api-common.gemspec
+++ b/manageiq-api-common.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "rails", ">= 5.2.1.1", "~> 5.2"
 
   # For ManageIQ::API::Common::Logging
-  spec.add_runtime_dependency "manageiq-loggers", "~> 0.1"
+  spec.add_runtime_dependency "manageiq-loggers", "~> 0.3"
+  spec.add_runtime_dependency "cloudwatchlogger", "~> 0.2"
 
   # For ManageIQ::API::Common::Metrics
   spec.add_runtime_dependency "prometheus-client", "~> 0.8.0"


### PR DESCRIPTION
Requires a new version of manageiq-loggers which includes https://github.com/ManageIQ/manageiq-loggers/pull/9