### PR TITLE
Switch from PrometheusClient to PrometheusExporter

### DIFF
--- a/lib/manageiq/api/common/metrics.rb
+++ b/lib/manageiq/api/common/metrics.rb
@@ -3,11 +3,35 @@ module ManageIQ
     module Common
       class Metrics
         def self.activate(config, prefix)
-          require 'prometheus/middleware/collector'
-          require 'prometheus/middleware/exporter'
+          require 'prometheus_exporter'
+          require 'prometheus_exporter/client'
 
-          config.middleware.use(Prometheus::Middleware::Collector, :metrics_prefix => prefix)
-          config.middleware.use(Prometheus::Middleware::Exporter)
+          ensure_exporter_server
+          enable_in_process_metrics
+          enable_web_server_metrics(prefix)
+        end
+
+        private_class_method def self.ensure_exporter_server
+          require 'socket'
+          TCPSocket.open("localhost", 9394) {}
+        rescue Errno::ECONNREFUSED
+          require 'prometheus_exporter/server'
+          server = PrometheusExporter::Server::WebServer.new(port: 9394)
+          server.start
+
+          PrometheusExporter::Client.default = PrometheusExporter::LocalClient.new(collector: server.collector)
+        end
+
+        private_class_method def self.enable_in_process_metrics
+          require 'prometheus_exporter/instrumentation'
+
+          # this reports basic process metrics such as RSS and Ruby metrics
+          PrometheusExporter::Instrumentation::Process.start
+        end
+
+        private_class_method def self.enable_web_server_metrics(prefix)
+          require "manageiq/api/common/middleware/web_server_metrics"
+          Rails.application.middleware.unshift(ManageIQ::API::Common::Middleware::WebServerMetrics, :metrics_prefix => prefix)
         end
       end
     end

--- a/lib/manageiq/api/common/middleware/web_server_metrics.rb
+++ b/lib/manageiq/api/common/middleware/web_server_metrics.rb
@@ -1,0 +1,56 @@
+module ManageIQ
+  module API
+    module Common
+      module Middleware
+        class WebServerMetrics
+          def initialize(app, options = {})
+            @app            = app
+            @metrics_prefix = options[:metrics_prefix] || "http_server"
+
+            require 'prometheus_exporter/client'
+            require 'prometheus_exporter/metric'
+
+            PrometheusExporter::Metric::Base.default_prefix = "#{@metrics_prefix}_"
+
+            @puma_busy_threads = PrometheusExporter::Client.default.register(:gauge, "puma_busy_threads", "The number of threads currently handling HTTP requests.")
+            @puma_max_threads  = PrometheusExporter::Client.default.register(:gauge, "puma_max_threads", "The total number of threads able to handle HTTP requests.")
+            @request_counter   = PrometheusExporter::Client.default.register(:counter, "requests_total", "The total number of HTTP requests handled by the Rack application.")
+            @request_histogram = PrometheusExporter::Client.default.register(:histogram, "request_duration_seconds", "The HTTP response duration of the Rack application.")
+          end
+
+          def call(env)
+            @puma_busy_threads.increment
+
+            result = nil
+            duration = Benchmark.realtime { result = @app.call(env) }
+            result
+          rescue => error
+            @error = error
+            raise
+          ensure
+            duration_labels = {
+              :method => env['REQUEST_METHOD'].downcase,
+              :path   => strip_ids_from_path(env['PATH_INFO']),
+            }
+
+            counter_labels = duration_labels.merge(:code => result.first.to_s).tap do |labels|
+              labels[:exception] = @error.class.name if @error
+            end
+
+            @request_counter.increment(counter_labels)
+            @request_histogram.observe(duration, duration_labels)
+
+            @puma_max_threads.observe(JSON.parse(Puma.stats)["max_threads"])
+            @puma_busy_threads.decrement
+          end
+
+          private
+
+          def strip_ids_from_path(path)
+            path.gsub(%r{/\d+(/|$)}, '/:id\\1')
+          end
+        end
+      end
+    end
+  end
+end

--- a/manageiq-api-common.gemspec
+++ b/manageiq-api-common.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "cloudwatchlogger", "~> 0.2"
 
   # For ManageIQ::API::Common::Metrics
-  spec.add_runtime_dependency "prometheus-client", "~> 0.8.0"
+  spec.add_runtime_dependency 'prometheus_exporter', '~> 0.4.5'
 
   # For ManageIQ::API::Common::OpenApi
   spec.add_runtime_dependency "more_core_extensions"


### PR DESCRIPTION
- Additional process metrics
- Add a counter for incoming requests (including exceptions)
- Add a histogram to track endpoint timings
- Add a gague to show the number of busy puma threads per server