### PR TITLE
Fix NoMethodError (undefined method `stats' for nil:NilClass)

### DIFF
--- a/lib/manageiq/api/common/middleware/web_server_metrics.rb
+++ b/lib/manageiq/api/common/middleware/web_server_metrics.rb
@@ -40,7 +40,7 @@ module ManageIQ
             @request_counter.increment(counter_labels)
             @request_histogram.observe(duration, duration_labels)
 
-            @puma_max_threads.observe(JSON.parse(Puma.stats)["max_threads"])
+            @puma_max_threads.observe(puma_stats["max_threads"])
             @puma_busy_threads.decrement
           end
 
@@ -48,6 +48,12 @@ module ManageIQ
 
           def strip_ids_from_path(path)
             path.gsub(%r{/\d+(/|$)}, '/:id\\1')
+          end
+
+          def puma_stats
+            JSON.parse(Puma.stats)
+          rescue NoMethodError
+            {}
           end
         end
       end


### PR DESCRIPTION
When the Puma server is not initialized (doing anything other than rails s) the @get_stats variable on the Puma module is not defined, so calling stats on it raises NoMethodError.