### PR TITLE
Improved the OpenAPI 3.0 post spec for the GraphQL endpoint.

### DIFF
--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -26,7 +26,26 @@ module ManageIQ
               "content"     => {
                 "application/json" => {
                   "schema" => {
-                    "type" => "object"
+                    "type"       => "object",
+                    "properties" => {
+                      "query"         => {
+                        "type"        => "string",
+                        "description" => "The GraphQL query",
+                        "default"     => "{}"
+                      },
+                      "operationName" => {
+                        "type"        => "string",
+                        "description" => "If the Query contains several named operations, the operationName controls which one should be executed",
+                        "default"     => ""
+                      },
+                      "variables"     => {
+                        "type"        => "object",
+                        "description" => "Optional Query variables"
+                      }
+                    },
+                    "required"   => [
+                      "query"
+                    ]
                   }
                 }
               },
@@ -39,7 +58,20 @@ module ManageIQ
                 "content"     => {
                   "application/json" => {
                     "schema" => {
-                      "type" => "object"
+                      "type"       => "object",
+                      "properties" => {
+                        "data"   => {
+                          "type"        => "object",
+                          "description" => "Results from the GraphQL query"
+                        },
+                        "errors" => {
+                          "type"        => "array",
+                          "description" => "Errors resulting from the GraphQL query",
+                          "items"       => {
+                            "type" => "object"
+                          }
+                        }
+                      }
                     }
                   }
                 }


### PR DESCRIPTION
Improved the OpenAPI 3.0 post spec for the GraphQL endpoint.
- mentioning the required query parameter as well as the optional operationName and variables in the payload
- mentioning the data and errors properties in the response