### PR TITLE
Drop relay based spec for base GraphQL query structure with filter/offset/limit

### DIFF
--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -3,6 +3,8 @@ require "graphql/batch"
 require "graphql/preload"
 
 require "manageiq/api/common/graphql/generator"
+require "manageiq/api/common/graphql/association_loader"
+require "manageiq/api/common/graphql/associated_records"
 
 require "manageiq/api/common/graphql/types/big_int"
 require "manageiq/api/common/graphql/types/date_time"

--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -86,11 +86,15 @@ module ManageIQ
           }
         end
 
-        def self.paginated_search(scope, args)
-          offset = (args[:offset] || 0).to_i.clamp(0, Float::INFINITY)
-          limit  = (args[:limit]  || 100).to_i.clamp(1, 1000)
+        def self.ordered_search(scope, _args)
+          scope.order(:id)
+        end
+
+        def self.paged_search(scope, args)
           scope  = scope.where(:id => args[:id]) if args[:id]
-          scope.order(:id).offset(offset).limit(limit).all
+          offset = (args[:offset] ||   0).to_i.clamp(0, Float::INFINITY)
+          limit  = (args[:limit]  || 100).to_i.clamp(1, 1000)
+          scope.offset(offset).limit(limit)
         end
 
         # Following code is auto-generated via rails generate graphql:install

--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -2,10 +2,9 @@ require "graphql"
 require "graphql/batch"
 require "graphql/preload"
 
-require "manageiq/api/common/graphql/generator"
 require "manageiq/api/common/graphql/association_loader"
 require "manageiq/api/common/graphql/associated_records"
-
+require "manageiq/api/common/graphql/generator"
 require "manageiq/api/common/graphql/types/big_int"
 require "manageiq/api/common/graphql/types/date_time"
 require "manageiq/api/common/graphql/types/query_filter"

--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -86,6 +86,13 @@ module ManageIQ
           }
         end
 
+        def self.paginated_search(scope, args)
+          offset = (args[:offset] || 0).to_i.clamp(0, Float::INFINITY)
+          limit  = (args[:limit]  || 100).to_i.clamp(1, 1000)
+          scope  = scope.where(:id => args[:id]) if args[:id]
+          scope.order(:id).offset(offset).limit(limit).all
+        end
+
         # Following code is auto-generated via rails generate graphql:install
         #
         # Handle form data, JSON body, or a blank value

--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -88,15 +88,9 @@ module ManageIQ
           }
         end
 
-        def self.ordered_search(scope, _args)
-          scope.order(:id)
-        end
-
-        def self.paged_search(scope, args)
-          scope  = scope.where(:id => args[:id]) if args[:id]
-          offset = (args[:offset] ||   0).to_i.clamp(0, Float::INFINITY)
-          limit  = (args[:limit]  || 100).to_i.clamp(1, 1000)
-          scope.offset(offset).limit(limit)
+        def self.search_options(scope, args)
+          scope = scope.where(:id => args[:id]) if args[:id]
+          scope
         end
 
         # Following code is auto-generated via rails generate graphql:install

--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -89,8 +89,7 @@ module ManageIQ
         end
 
         def self.search_options(scope, args)
-          scope = scope.where(:id => args[:id]) if args[:id]
-          scope
+          args[:id] ? scope.where(:id => args[:id]) : scope
         end
 
         # Following code is auto-generated via rails generate graphql:install

--- a/lib/manageiq/api/common/graphql/associated_records.rb
+++ b/lib/manageiq/api/common/graphql/associated_records.rb
@@ -26,12 +26,12 @@ module ManageIQ
 
           def filter_collection_by_options(options)
             res = @collection
+            if options[:where].present?
+              options[:where].each_pair { |k, v| res = res.select { |rec| rec[k].to_s == v.to_s } }
+            end
             if options[:order].present?
               order_by = options[:order].first
               res = res.sort_by { |rec| rec[order_by] }
-            end
-            if options[:where].present?
-              options[:where].each_pair { |k, v| res = res.select { |rec| rec[k].to_s == v.to_s } }
             end
             res = res.drop(options[:offset]) if options[:offset]
             res = res.take(options[:limit])  if options[:limit]

--- a/lib/manageiq/api/common/graphql/associated_records.rb
+++ b/lib/manageiq/api/common/graphql/associated_records.rb
@@ -8,7 +8,7 @@ module ManageIQ
           include Enumerable
           include QueryRelation::Queryable
 
-          def initialize(collection = [])
+          def initialize(collection)
             @collection = collection
           end
 

--- a/lib/manageiq/api/common/graphql/associated_records.rb
+++ b/lib/manageiq/api/common/graphql/associated_records.rb
@@ -27,7 +27,8 @@ module ManageIQ
           def filter_collection_by_options(options)
             res = @collection
             if options[:order].present?
-              options[:order].each { |attr| res = res.sort_by { |rec| rec[attr] } }
+              order_by = options[:order].first
+              res = res.sort_by { |rec| rec[order_by] }
             end
             if options[:where].present?
               options[:where].each_pair { |k, v| res = res.select { |rec| rec[k].to_s == v.to_s } }

--- a/lib/manageiq/api/common/graphql/associated_records.rb
+++ b/lib/manageiq/api/common/graphql/associated_records.rb
@@ -1,0 +1,43 @@
+require "query_relation"
+
+module ManageIQ
+  module API
+    module Common
+      module GraphQL
+        class AssociatedRecords
+          include Enumerable
+          include QueryRelation::Queryable
+
+          def initialize(collection = [])
+            @collection = collection
+          end
+
+          private
+
+          def search(mode, options)
+            res = filter_collection_by_options(options)
+
+            case mode
+            when :first then res.first
+            when :last  then res.last
+            when :all   then res
+            end
+          end
+
+          def filter_collection_by_options(options)
+            res = @collection
+            if options[:order].present?
+              options[:order].each { |attr| res = res.sort_by { |rec| rec[attr] } }
+            end
+            if options[:where].present?
+              options[:where].each_pair { |k, v| res = res.select { |rec| rec[k].to_s == v.to_s } }
+            end
+            res = res.drop(options[:offset]) if options[:offset]
+            res = res.take(options[:limit])  if options[:limit]
+            res
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/api/common/graphql/association_loader.rb
+++ b/lib/manageiq/api/common/graphql/association_loader.rb
@@ -23,8 +23,10 @@ module ManageIQ
 
           def read_association(record)
             recs = ::ManageIQ::API::Common::GraphQL::AssociatedRecords.new(record.public_send(association_name).to_a)
-            recs = ::ManageIQ::API::Common::GraphQL.ordered_search(recs, args)
-            ::ManageIQ::API::Common::GraphQL.paged_search(recs, args)
+            recs = ::ManageIQ::API::Common::GraphQL.search_options(recs, args)
+            ::ManageIQ::API::Common::PaginatedResponse.new(
+              :base_query => recs, :request => nil, :limit => args[:limit], :offset => args[:offset]
+            ).search
           end
         end
       end

--- a/lib/manageiq/api/common/graphql/association_loader.rb
+++ b/lib/manageiq/api/common/graphql/association_loader.rb
@@ -1,0 +1,33 @@
+module ManageIQ
+  module API
+    module Common
+      module GraphQL
+        class AssociationLoader < ::GraphQL::Batch::Loader
+          attr_reader :model, :association_name, :args
+
+          def initialize(model, association_name, args = {})
+            @model            = model
+            @association_name = association_name
+            @args             = args
+          end
+
+          def cache_key(record)
+            record.object_id
+          end
+
+          def perform(records)
+            records.each { |record| fulfill(record, read_association(record)) }
+          end
+
+          private
+
+          def read_association(record)
+            recs = ::ManageIQ::API::Common::GraphQL::AssociatedRecords.new(record.public_send(association_name).to_a)
+            recs = ::ManageIQ::API::Common::GraphQL.ordered_search(recs, args)
+            ::ManageIQ::API::Common::GraphQL.paged_search(recs, args)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/api/common/graphql/association_loader.rb
+++ b/lib/manageiq/api/common/graphql/association_loader.rb
@@ -22,9 +22,9 @@ module ManageIQ
           private
 
           def read_association(record)
-            recs = ::ManageIQ::API::Common::GraphQL::AssociatedRecords.new(record.public_send(association_name).to_a)
-            recs = ::ManageIQ::API::Common::GraphQL.search_options(recs, args)
-            ::ManageIQ::API::Common::PaginatedResponse.new(
+            recs = GraphQL::AssociatedRecords.new(record.public_send(association_name).to_a)
+            recs = GraphQL.search_options(recs, args)
+            PaginatedResponse.new(
               :base_query => recs, :request => nil, :limit => args[:limit], :offset => args[:offset]
             ).search
           end

--- a/lib/manageiq/api/common/graphql/association_loader.rb
+++ b/lib/manageiq/api/common/graphql/association_loader.rb
@@ -22,7 +22,7 @@ module ManageIQ
           private
 
           def read_association(record)
-            recs = GraphQL::AssociatedRecords.new(record.public_send(association_name).to_a)
+            recs = GraphQL::AssociatedRecords.new(record.public_send(association_name))
             recs = GraphQL.search_options(recs, args)
             PaginatedResponse.new(
               :base_query => recs, :request => nil, :limit => args[:limit], :offset => args[:offset]

--- a/lib/manageiq/api/common/graphql/association_loader.rb
+++ b/lib/manageiq/api/common/graphql/association_loader.rb
@@ -3,7 +3,7 @@ module ManageIQ
     module Common
       module GraphQL
         class AssociationLoader < ::GraphQL::Batch::Loader
-          attr_reader :model, :association_name, :args
+          attr_reader :args, :association_name, :model
 
           def initialize(model, association_name, args = {})
             @model            = model

--- a/lib/manageiq/api/common/graphql/association_loader.rb
+++ b/lib/manageiq/api/common/graphql/association_loader.rb
@@ -26,7 +26,7 @@ module ManageIQ
             recs = GraphQL.search_options(recs, args)
             PaginatedResponse.new(
               :base_query => recs, :request => nil, :limit => args[:limit], :offset => args[:offset]
-            ).search
+            ).records
           end
         end
       end

--- a/lib/manageiq/api/common/graphql/generator.rb
+++ b/lib/manageiq/api/common/graphql/generator.rb
@@ -60,7 +60,7 @@ module ManageIQ
           end
 
           def self.init_schema(request, schema_overlay = {})
-            api_version       = ::ManageIQ::API::Common::GraphQL.version(request)
+            api_version       = GraphQL.version(request)
             version_namespace = "V#{api_version.tr('.', 'x')}"
             openapi_content   = ::ManageIQ::API::Common::OpenApi::Docs.instance[api_version].content
 

--- a/lib/manageiq/api/common/graphql/generator.rb
+++ b/lib/manageiq/api/common/graphql/generator.rb
@@ -60,7 +60,7 @@ module ManageIQ
           end
 
           def self.init_schema(request, schema_overlay = {})
-            api_version       = GraphQL.version(request)
+            api_version       = ::ManageIQ::API::Common::GraphQL.version(request)
             version_namespace = "V#{api_version.tr('.', 'x')}"
             openapi_content   = ::ManageIQ::API::Common::OpenApi::Docs.instance[api_version].content
 

--- a/lib/manageiq/api/common/graphql/templates/model_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/model_type.erb
@@ -15,7 +15,6 @@
 <%   model_associations.each do |association| %>
 <%     associations = association.pluralize %>
 <%     association_class_name  = association.camelize.singularize %>
-<%     association_class = association_class_name.constantize %>
 
   field :<%= associations %> do
     description "The <%= associations %> associated with this <%= klass_name %>"
@@ -24,21 +23,12 @@
     argument :id, types.ID
     argument :offset, types.Int, "The number of <%= associations %> to skip before starting to collect the result set"
     argument :limit,  types.Int, "The number of <%= associations %> to return"
-    argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the associated <%= associations %>"
 
     preload :<%= associations %>
-    preload_scope ->(args, ctx) do
-      scope = ::ManageIQ::API::Common::GraphQL.ordered_search(<%= association_class %>, args)
-      if args[:filter]
-        scope = ::ManageIQ::API::Common::Filter.new(
-                  scope,
-                  ActionController::Parameters.new(args[:filter]),
-                  ::Api::Docs["<%= api_version %>"].definitions["<%= association_class_name %>"]).apply
-      end
-      ::ManageIQ::API::Common::GraphQL.paged_search(scope, args)
-    end
 
-    resolve lambda { |obj, _args, _ctx| obj.<%= associations %> }
+    resolve lambda { |obj, args, _ctx|
+      ::ManageIQ::API::Common::GraphQL::AssociationLoader.new(<%= klass_name.constantize %>, "<%= associations %>", args).load(obj)
+    }
   end
 <%   end %>
 <% end %>

--- a/lib/manageiq/api/common/graphql/templates/model_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/model_type.erb
@@ -15,6 +15,7 @@
 <%   model_associations.each do |association| %>
 <%     associations = association.pluralize %>
 <%     association_class_name  = association.camelize.singularize %>
+<%     association_class = association_class_name.constantize %>
 
   field :<%= associations %> do
     description "The <%= associations %> associated with this <%= klass_name %>"
@@ -25,17 +26,19 @@
     argument :limit,  types.Int, "The number of <%= associations %> to return"
     argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the associated <%= associations %>"
 
-    resolve lambda { |obj, args, _ctx|
-      scope = if args[:filter]
-                ::ManageIQ::API::Common::Filter.new(obj.<%= associations %>,
-                                                    ActionController::Parameters.new(args[:filter]),
-                                                    ::Api::Docs["<%= api_version %>"].definitions["<%= association_class_name %>"]).apply
+    preload :<%= associations %>
+    preload_scope ->(args, ctx) do
+      scope = ::ManageIQ::API::Common::GraphQL.ordered_search(<%= association_class %>, args)
+      if args[:filter]
+        scope = ::ManageIQ::API::Common::Filter.new(
+                  scope,
+                  ActionController::Parameters.new(args[:filter]),
+                  ::Api::Docs["<%= api_version %>"].definitions["<%= association_class_name %>"]).apply
+      end
+      ::ManageIQ::API::Common::GraphQL.paged_search(scope, args)
+    end
 
-              else
-                obj.<%= associations %>
-              end
-      ::ManageIQ::API::Common::GraphQL.paginated_search(scope, args)
-    }
+    resolve lambda { |obj, _args, _ctx| obj.<%= associations %> }
   end
 <%   end %>
 <% end %>

--- a/lib/manageiq/api/common/graphql/templates/model_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/model_type.erb
@@ -1,10 +1,6 @@
 <%= klass_name %>Type = ::GraphQL::ObjectType.define do
   name "<%= klass_name %>"
   description "A <%= klass_name %>"
-<% if model_is_associated %>
-
-  implements ::GraphQL::Relay::Node.interface
-<% end %>
 
 <% model_properties.each do |property| %>
 <%   property_name, property_type, property_description = property %>
@@ -17,10 +13,29 @@
 <% end %>
 <% if model_associations.present? %>
 <%   model_associations.each do |association| %>
-<%     connection = "#{association.pluralize}" %>
-<%     connection_type   = "#{association.camelize.singularize}Type.connection_type" %>
-  connection :<%= connection %>, <%= connection_type %>, "The <%= connection %> associated with this <%= klass_name %>Type" do
-    preload :<%= association %>
+<%     associations = association.pluralize %>
+<%     association_class_name  = association.camelize.singularize %>
+
+  field :<%= associations %> do
+    description "The <%= associations %> associated with this <%= klass_name %>"
+    type types[<%= "#{association_class_name}Type" %>]
+
+    argument :id, types.ID
+    argument :offset, types.Int, "The number of <%= associations %> to skip before starting to collect the result set"
+    argument :limit,  types.Int, "The number of <%= associations %> to return"
+    argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the associated <%= associations %>"
+
+    resolve lambda { |obj, args, _ctx|
+      scope = if args[:filter]
+                ::ManageIQ::API::Common::Filter.new(obj.<%= associations %>,
+                                                    ActionController::Parameters.new(args[:filter]),
+                                                    ::Api::Docs["<%= api_version %>"].definitions["<%= association_class_name %>"]).apply
+
+              else
+                obj.<%= associations %>
+              end
+      ::ManageIQ::API::Common::GraphQL.paginated_search(scope, args)
+    }
   end
 <%   end %>
 <% end %>

--- a/lib/manageiq/api/common/graphql/templates/query_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/query_type.erb
@@ -30,7 +30,7 @@ QueryType = ::GraphQL::ObjectType.define do
         scope = ::ManageIQ::API::Common::GraphQL.search_options(scope, args)
         ::ManageIQ::API::Common::PaginatedResponse.new(
           base_query: scope, request: nil, limit: args[:limit], offset: args[:offset]
-        ).search
+        ).records
       }
     end
   end

--- a/lib/manageiq/api/common/graphql/templates/query_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/query_type.erb
@@ -19,16 +19,15 @@ QueryType = ::GraphQL::ObjectType.define do
       argument :offset, types.Int, "The number of #{collection} to skip before starting to collect the result set"
       argument :limit,  types.Int, "The number of #{collection} to return"
       argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the #{collection}"
-
       resolve lambda { |_obj, args, _ctx|
-        scope = if args[:filter]
-                  ::ManageIQ::API::Common::Filter.new(model_class,
-                                                      ActionController::Parameters.new(args[:filter]),
-                                                      ::ManageIQ::API::Common::OpenApi::Docs.instance["<%= api_version %>"].definitions[klass_name]).apply
-                else
-                  model_class
-                end
-        ::ManageIQ::API::Common::GraphQL.paginated_search(scope, args)
+        scope = ::ManageIQ::API::Common::GraphQL.ordered_search(model_class, args)
+        if args[:filter]
+          scope = ::ManageIQ::API::Common::Filter.new(
+            scope,
+            ActionController::Parameters.new(args[:filter]),
+            ::ManageIQ::API::Common::OpenApi::Docs.instance["<%= api_version %>"].definitions[klass_name]).apply
+        end
+        ::ManageIQ::API::Common::GraphQL.paged_search(scope, args)
       }
     end
   end

--- a/lib/manageiq/api/common/graphql/templates/query_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/query_type.erb
@@ -11,9 +11,14 @@ QueryType = ::GraphQL::ObjectType.define do
     model_class   = klass_name.constantize
     resource_type = "Api::#{version_namespace}::GraphQL::#{klass_name}Type".constantize
 
-    connection collection, !resource_type.connection_type, "List available #{klass_names}" do
+    field collection do
+      description "List available #{collection}"
+      type types[resource_type]
+
       argument :id, types.ID
-      argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter"
+      argument :offset, types.Int, "The number of #{collection} to skip before starting to collect the result set"
+      argument :limit,  types.Int, "The number of #{collection} to return"
+      argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the #{collection}"
 
       resolve lambda { |_obj, args, _ctx|
         scope = if args[:filter]
@@ -23,7 +28,7 @@ QueryType = ::GraphQL::ObjectType.define do
                 else
                   model_class
                 end
-        args[:id] ? scope.where(:id => args[:id]) : scope.all
+        ::ManageIQ::API::Common::GraphQL.paginated_search(scope, args)
       }
     end
   end

--- a/lib/manageiq/api/common/graphql/templates/query_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/query_type.erb
@@ -20,14 +20,17 @@ QueryType = ::GraphQL::ObjectType.define do
       argument :limit,  types.Int, "The number of #{collection} to return"
       argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the #{collection}"
       resolve lambda { |_obj, args, _ctx|
-        scope = ::ManageIQ::API::Common::GraphQL.ordered_search(model_class, args)
+        scope = model_class
         if args[:filter]
           scope = ::ManageIQ::API::Common::Filter.new(
             scope,
             ActionController::Parameters.new(args[:filter]),
             ::ManageIQ::API::Common::OpenApi::Docs.instance["<%= api_version %>"].definitions[klass_name]).apply
         end
-        ::ManageIQ::API::Common::GraphQL.paged_search(scope, args)
+        scope = ::ManageIQ::API::Common::GraphQL.search_options(scope, args)
+        ::ManageIQ::API::Common::PaginatedResponse.new(
+          base_query: scope, request: nil, limit: args[:limit], offset: args[:offset]
+        ).search
       }
     end
   end

--- a/lib/manageiq/api/common/paginated_response.rb
+++ b/lib/manageiq/api/common/paginated_response.rb
@@ -11,16 +11,16 @@ module ManageIQ
           @offset     = (offset || 0).to_i.clamp(0, Float::INFINITY)
         end
 
+        def records
+          @records ||= @base_query.order(:id).limit(limit).offset(offset)
+        end
+
         def response
           {
             "meta"  => metadata_hash,
             "links" => links_hash,
             "data"  => records
           }
-        end
-
-        def search
-          @base_query.order(:id).limit(limit).offset(offset)
         end
 
         private
@@ -85,10 +85,6 @@ module ManageIQ
 
         def count
           @count ||= @base_query.count
-        end
-
-        def records
-          @records ||= search
         end
       end
     end

--- a/lib/manageiq/api/common/paginated_response.rb
+++ b/lib/manageiq/api/common/paginated_response.rb
@@ -19,6 +19,10 @@ module ManageIQ
           }
         end
 
+        def search
+          @base_query.order(:id).limit(limit).offset(offset)
+        end
+
         private
 
         def metadata_hash
@@ -84,7 +88,7 @@ module ManageIQ
         end
 
         def records
-          @records ||= @base_query.order(:id).limit(limit).offset(offset)
+          @records ||= search
         end
       end
     end

--- a/manageiq-api-common.gemspec
+++ b/manageiq-api-common.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   # For ManageIQ::API::Common::GraphQL
   spec.add_runtime_dependency "graphql",         "~> 1.9"
   spec.add_runtime_dependency "graphql-batch",   "~> 0.4"
-  spec.add_runtime_dependency "graphql-preload", "~> 2.0.1"
+  spec.add_runtime_dependency "graphql-preload", "~> 2.0", "< 2.1"
   spec.add_runtime_dependency "query_relation"
 
   spec.add_development_dependency "factory_bot"

--- a/manageiq-api-common.gemspec
+++ b/manageiq-api-common.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "graphql",         "~> 1.9"
   spec.add_runtime_dependency "graphql-batch",   "~> 0.4"
   spec.add_runtime_dependency "graphql-preload", "~> 2.0.1"
+  spec.add_runtime_dependency "query_relation"
 
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/manageiq-api-common.gemspec
+++ b/manageiq-api-common.gemspec
@@ -31,9 +31,9 @@ Gem::Specification.new do |spec|
 
 
   # For ManageIQ::API::Common::GraphQL
-  spec.add_runtime_dependency "graphql",         "~> 1.7"
-  spec.add_runtime_dependency "graphql-batch",   "~> 0.3.8"
-  spec.add_runtime_dependency "graphql-preload", "~> 1.0"
+  spec.add_runtime_dependency "graphql",         "~> 1.9"
+  spec.add_runtime_dependency "graphql-batch",   "~> 0.4"
+  spec.add_runtime_dependency "graphql-preload", "~> 2.0.1"
 
   spec.add_development_dependency "factory_bot"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Drop support for the relay based specification and implements the base GraphQL query structure.
- Adding support for the following on collections:
  - offset
  - limit
  - filter

- And the following on associations:
  - offset
  - limit

Example with topological inventory:

```
{
  container_groups(filter: { name: { starts_with: "sources"}}) {
    id
    name
    containers (offset: 90, limit: 30) {
      id
      name
      archived_at
    }
    tags (offset: 20, limit: 20) {
      id
      description
    }
  }
}
```

Example with sources:

```
{
  sources(offset: 10, limit: 10, filter: { name: "OpenShift"}) {
    id
    name
    endpoints {
      id
      scheme
      host
      port
      path
      authentications {
        id
        username
        status
      }
    }
  }
}
```