### PR TITLE
Removed OpenAPI Regexp validation

### DIFF
--- a/lib/manageiq/api/common/open_api/docs/component_collection.rb
+++ b/lib/manageiq/api/common/open_api/docs/component_collection.rb
@@ -57,8 +57,7 @@ module ManageIQ
             end
 
             def regexp_from_pattern(pattern)
-              raise "Pattern #{pattern.inspect} is not a regular expression" unless pattern.starts_with?("/") && pattern.ends_with?("/")
-              Regexp.new(pattern[1..-2])
+              Regexp.new(pattern)
             end
           end
         end


### PR DESCRIPTION
Swagger doc Definition doesn't want '/' at the start/end of pattern.
https://swagger.io/docs/specification/data-models/data-types/#pattern

`OpenAPIParser` validates pattern and wraps pattern with '/', so this check is not compatible.
Wrong definition is for example there:
https://github.com/ManageIQ/sources-api/blob/master/public/doc/openapi-3-v1.0.0.json#L1200
check value against pattern here: https://github.com/ota42y/openapi_parser/blob/master/lib/openapi_parser/schema_validators/string_validator.rb#L50

Happened during implementation of https://github.com/ManageIQ/manageiq-api-common/issues/67

cc @bdunne @Ladas @abellotti 
  