### PR TITLE
Fix constant problems

### DIFF
--- a/lib/manageiq/api/common/graphql/generator.rb
+++ b/lib/manageiq/api/common/graphql/generator.rb
@@ -62,7 +62,7 @@ module ManageIQ
           def self.init_schema(request, schema_overlay = {})
             api_version       = ::ManageIQ::API::Common::GraphQL.version(request)
             version_namespace = "V#{api_version.tr('.', 'x')}"
-            openapi_content   = Api::Docs[api_version].content
+            openapi_content   = ::ManageIQ::API::Common::OpenApi::Docs.instance[api_version].content
 
             api_namespace = if ::Api.const_defined?(version_namespace, false)
                               ::Api.const_get(version_namespace)

--- a/lib/manageiq/api/common/graphql/templates/query_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/query_type.erb
@@ -19,7 +19,7 @@ QueryType = ::GraphQL::ObjectType.define do
         scope = if args[:filter]
                   ::ManageIQ::API::Common::Filter.new(model_class,
                                                       ActionController::Parameters.new(args[:filter]),
-                                                      ::Api::Docs["<%= api_version %>"].definitions[klass_name]).apply
+                                                      ::ManageIQ::API::Common::OpenApi::Docs.instance["<%= api_version %>"].definitions[klass_name]).apply
                 else
                   model_class
                 end

--- a/lib/manageiq/api/common/open_api/docs.rb
+++ b/lib/manageiq/api/common/open_api/docs.rb
@@ -7,6 +7,10 @@ module ManageIQ
     module Common
       module OpenApi
         class Docs
+          def self.instance
+            @instance ||= new(Dir.glob(Rails.root.join("public", "doc", "openapi*.json")))
+          end
+
           def initialize(glob)
             @cache = {}
             glob.each { |f| load_file(f) }

--- a/lib/manageiq/api/common/open_api/docs/component_collection.rb
+++ b/lib/manageiq/api/common/open_api/docs/component_collection.rb
@@ -21,7 +21,7 @@ module ManageIQ
 
               definition = substitute_regexes(raw_definition)
               definition = substitute_references(definition)
-              self[name] = OpenApi::Docs::ObjectDefinition.new.replace(definition)
+              self[name] = ::ManageIQ::API::Common::OpenApi::Docs::ObjectDefinition.new.replace(definition)
             end
 
             private

--- a/lib/manageiq/api/common/open_api/docs/doc_v3.rb
+++ b/lib/manageiq/api/common/open_api/docs/doc_v3.rb
@@ -39,11 +39,11 @@ module ManageIQ
             end
 
             def parameters
-              @parameters ||= OpenApi::Docs::ComponentCollection.new(self, "components/parameters")
+              @parameters ||= ::ManageIQ::API::Common::OpenApi::Docs::ComponentCollection.new(self, "components/parameters")
             end
 
             def schemas
-              @schemas ||= OpenApi::Docs::ComponentCollection.new(self, "components/schemas")
+              @schemas ||= ::ManageIQ::API::Common::OpenApi::Docs::ComponentCollection.new(self, "components/schemas")
             end
 
             def definitions

--- a/lib/manageiq/api/common/open_api/serializer.rb
+++ b/lib/manageiq/api/common/open_api/serializer.rb
@@ -9,7 +9,7 @@ module ManageIQ
             encryption_filtered = previous.except(*encrypted_columns_set)
             return encryption_filtered unless arg.key?(:prefixes)
             version = api_version_from_prefix(arg[:prefixes].first)
-            schema  = Api::Docs[version].definitions[self.class.name]
+            schema  = ::ManageIQ::API::Common::OpenApi::Docs.instance[version].definitions[self.class.name]
             attrs   = encryption_filtered.slice(*schema["properties"].keys)
             schema["properties"].keys.each do |name|
               next if attrs[name].nil?
@@ -19,7 +19,7 @@ module ManageIQ
             end
             attrs.compact
           end
-      
+
           def api_version_from_prefix(prefix)
             /\/?\w+\/v(?<major>\d+)[x\.]?(?<minor>\d+)?\// =~ prefix
             [major, minor].compact.join(".")


### PR DESCRIPTION
Occasionally we get an error about missing constant ManageIQ::Api::Docs
which should be actually be finding ::Api::Docs in lib/api/docs.rb in the
apps, but for some reason that isn't loaded yet.  Instead, move all of this
logic to manageiq-api-common and create
::ManageIQ::API::Common::OpenApi::Docs.instance