### PR TITLE
Splitting the GraphQL OpenAPI description

### DIFF
--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -58,22 +58,28 @@ module ManageIQ
                 "content"     => {
                   "application/json" => {
                     "schema" => {
-                      "type"       => "object",
-                      "properties" => {
-                        "data"   => {
-                          "type"        => "object",
-                          "description" => "Results from the GraphQL query"
-                        },
-                        "errors" => {
-                          "type"        => "array",
-                          "description" => "Errors resulting from the GraphQL query",
-                          "items"       => {
-                            "type" => "object"
-                          }
-                        }
-                      }
+                      "$ref" => "#/components/schemas/GraphQLResponse"
                     }
                   }
+                }
+              }
+            }
+          }
+        end
+
+        def self.openapi_graphql_response
+          {
+            "type"       => "object",
+            "properties" => {
+              "data"   => {
+                "type"        => "object",
+                "description" => "Results from the GraphQL query"
+              },
+              "errors" => {
+                "type"        => "array",
+                "description" => "Errors resulting from the GraphQL query",
+                "items"       => {
+                  "type" => "object"
                 }
               }
             }


### PR DESCRIPTION
- Moving the GraphQL Response into a separate schema definition as the client generator was getting confused with the inline response definition.