### PR TITLE
Updated how we find the openapi json in OpenApi::Docs.instance

### DIFF
--- a/lib/manageiq/api/common/open_api/docs.rb
+++ b/lib/manageiq/api/common/open_api/docs.rb
@@ -8,7 +8,7 @@ module ManageIQ
       module OpenApi
         class Docs
           def self.instance
-            @instance ||= new(Dir.glob(Rails.root.join("public", "doc", "openapi*.json")))
+            @instance ||= new(Dir.glob(Rails.root.join("public", "**", "openapi*.json")))
           end
 
           def initialize(glob)


### PR DESCRIPTION
Updated how we find the OpenAPI json in OpenApi::Docs.instance so this code also works with catalog api as they have the OpenAPI docs in a different location than topological inventory and sources.