### PR TITLE
Support Alternate OpenAPI Schema Class Name

### DIFF
--- a/lib/manageiq/api/common/graphql/templates/query_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/query_type.erb
@@ -22,10 +22,12 @@ QueryType = ::GraphQL::ObjectType.define do
       resolve lambda { |_obj, args, _ctx|
         scope = model_class
         if args[:filter]
+          openapi_doc = ::ManageIQ::API::Common::OpenApi::Docs.instance["<%= api_version %>"]
+          openapi_schema_name, _schema = ::ManageIQ::API::Common::GraphQL::Generator.openapi_schema(openapi_doc, klass_name)
           scope = ::ManageIQ::API::Common::Filter.new(
             scope,
             ActionController::Parameters.new(args[:filter]),
-            ::ManageIQ::API::Common::OpenApi::Docs.instance["<%= api_version %>"].definitions[klass_name]).apply
+            openapi_doc.definitions[openapi_schema_name]).apply
         end
         scope = ::ManageIQ::API::Common::GraphQL.search_options(scope, args)
         ::ManageIQ::API::Common::PaginatedResponse.new(


### PR DESCRIPTION
Support for ClassName as well as ClassNameOut schema name definition in the OpenAPI spec.

This allows us support either the default ClassName or alternate ClassNameOut as used by the approval-api service. While a more elaborate implementation via the schema_overlay parameter can be done to allow for arbitrary name mappings, it seemed unnecessary for this one case (i.e. over engineered), we can revisit if another micro-service has a similar requirement but needing a different mapping.