### PR TITLE
Adding support for an optional base_query 

### DIFF
--- a/lib/manageiq/api/common/graphql/generator.rb
+++ b/lib/manageiq/api/common/graphql/generator.rb
@@ -72,7 +72,7 @@ module ManageIQ
             schema_overlay.keys.each do |collection_regex|
               next unless collection.match(collection_regex)
 
-              collection_schema_overlay.merge!(schema_overlay.fetch_path(collection_regex) || {})
+              collection_schema_overlay.merge!(schema_overlay[collection_regex] || {})
             end
             collection_schema_overlay
           end

--- a/lib/manageiq/api/common/graphql/generator.rb
+++ b/lib/manageiq/api/common/graphql/generator.rb
@@ -67,6 +67,16 @@ module ManageIQ
             field_resolvers
           end
 
+          def self.collection_schema_overlay(schema_overlay, collection)
+            collection_schema_overlay = {}
+            schema_overlay.keys.each do |collection_regex|
+              next unless collection.match(collection_regex)
+
+              collection_schema_overlay.merge!(schema_overlay.fetch_path(collection_regex) || {})
+            end
+            collection_schema_overlay
+          end
+
           def self.init_schema(request, schema_overlay = {})
             api_version       = ::ManageIQ::API::Common::GraphQL.version(request)
             version_namespace = "V#{api_version.tr('.', 'x')}"

--- a/lib/manageiq/api/common/graphql/generator.rb
+++ b/lib/manageiq/api/common/graphql/generator.rb
@@ -68,13 +68,11 @@ module ManageIQ
           end
 
           def self.collection_schema_overlay(schema_overlay, collection)
-            collection_schema_overlay = {}
-            schema_overlay.keys.each do |collection_regex|
+            schema_overlay.keys.each_with_object({}) do |collection_regex, collection_schema_overlay|
               next unless collection.match(collection_regex)
 
               collection_schema_overlay.merge!(schema_overlay[collection_regex] || {})
             end
-            collection_schema_overlay
           end
 
           def self.init_schema(request, schema_overlay = {})

--- a/lib/manageiq/api/common/graphql/generator.rb
+++ b/lib/manageiq/api/common/graphql/generator.rb
@@ -69,7 +69,7 @@ module ManageIQ
 
           def self.collection_schema_overlay(schema_overlay, collection)
             schema_overlay.keys.each_with_object({}) do |collection_regex, collection_schema_overlay|
-              next unless collection.match(collection_regex)
+              next unless collection.match?(collection_regex)
 
               collection_schema_overlay.merge!(schema_overlay[collection_regex] || {})
             end

--- a/lib/manageiq/api/common/graphql/templates/query_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/query_type.erb
@@ -24,8 +24,7 @@ QueryType = ::GraphQL::ObjectType.define do
       argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the #{collection}"
       resolve lambda { |_obj, args, ctx|
         if base_query.present?
-          impl, method = base_query.split('.')
-          scope = impl.constantize.send(method, model_class, ctx)
+          scope = base_query.call(model_class, ctx)
         else
           scope = model_class
         end

--- a/lib/manageiq/api/common/graphql/templates/query_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/query_type.erb
@@ -11,6 +11,9 @@ QueryType = ::GraphQL::ObjectType.define do
     model_class   = klass_name.constantize
     resource_type = "Api::#{version_namespace}::GraphQL::#{klass_name}Type".constantize
 
+    collection_schema_overlay = ::ManageIQ::API::Common::GraphQL::Generator.collection_schema_overlay(schema_overlay, collection)
+    base_query                = collection_schema_overlay["base_query"]
+
     field collection do
       description "List available #{collection}"
       type types[resource_type]
@@ -19,8 +22,14 @@ QueryType = ::GraphQL::ObjectType.define do
       argument :offset, types.Int, "The number of #{collection} to skip before starting to collect the result set"
       argument :limit,  types.Int, "The number of #{collection} to return"
       argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the #{collection}"
-      resolve lambda { |_obj, args, _ctx|
-        scope = model_class
+      resolve lambda { |_obj, args, ctx|
+        if base_query.present?
+          impl, method = base_query.split('.')
+          scope = impl.constantize.send(method, model_class, ctx)
+        else
+          scope = model_class
+        end
+
         if args[:filter]
           openapi_doc = ::ManageIQ::API::Common::OpenApi::Docs.instance["<%= api_version %>"]
           openapi_schema_name, _schema = ::ManageIQ::API::Common::GraphQL::Generator.openapi_schema(openapi_doc, klass_name)


### PR DESCRIPTION
Adding support for an optional base_query provided by the GraphQL controller for defining a base_query via the schema overlay for the different model queries.

Example would be something like:

```
  schema_overlay = {
    "^.*$" => {
      "base_query" => ::Api::GraphqlController.method(:base_query)
    }
  }

  graphql_api_schema = ::ManageIQ::API::Common::GraphQL::Generator.init_schema(request, schema_overlay)
```

Calls to ::Api::GraphqlController base_query would be as follows:

```
::Api::GraqhqlController.base_query(model_class, ctx)
```

Where ctx is the field resolver context.