### PR TITLE
Support for non openapi controllers

### DIFF
--- a/lib/manageiq/api/common/application_controller_mixins/openapi_enabled.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/openapi_enabled.rb
@@ -1,0 +1,13 @@
+module ManageIQ
+  module API
+    module Common
+      module ApplicationControllerMixins
+        module OpenapiEnabled
+          def self.included(other)
+            other.class_attribute :openapi_enabled, :default => true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
@@ -38,6 +38,7 @@ module ManageIQ
           # - only for HTTP POST/PATCH
           def validate_request
             return unless request.post? || request.patch?
+            return unless self.class.to_s.split('::').length > 2
 
             api_version = self.class.send(:api_version)[1..-1].sub(/x/, ".")
 

--- a/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
@@ -7,7 +7,6 @@ module ManageIQ
           end
 
           def self.included(other)
-            other.class_attribute :openapi_enabled, :default => true
             ActionController::Parameters.action_on_unpermitted_parameters = :raise
 
             other.before_action(:validate_request)

--- a/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
@@ -7,7 +7,7 @@ module ManageIQ
           end
 
           def self.included(other)
-            @@openapi_enabled = true
+            other.class_attribute :openapi_enabled, :default => true
             ActionController::Parameters.action_on_unpermitted_parameters = :raise
 
             other.before_action(:validate_request)
@@ -39,7 +39,7 @@ module ManageIQ
           # - only for HTTP POST/PATCH
           def validate_request
             return unless request.post? || request.patch?
-            return unless @@openapi_enabled
+            return unless self.class.openapi_enabled
 
             api_version = self.class.send(:api_version)[1..-1].sub(/x/, ".")
 

--- a/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
@@ -8,6 +8,7 @@ module ManageIQ
 
           def self.included(other)
             ActionController::Parameters.action_on_unpermitted_parameters = :raise
+
             other.include(OpenapiEnabled)
 
             other.before_action(:validate_request)

--- a/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
@@ -8,6 +8,7 @@ module ManageIQ
 
           def self.included(other)
             ActionController::Parameters.action_on_unpermitted_parameters = :raise
+            other.include(OpenapiEnabled)
 
             other.before_action(:validate_request)
 

--- a/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_body_validation.rb
@@ -7,6 +7,7 @@ module ManageIQ
           end
 
           def self.included(other)
+            @@openapi_enabled = true
             ActionController::Parameters.action_on_unpermitted_parameters = :raise
 
             other.before_action(:validate_request)
@@ -38,7 +39,7 @@ module ManageIQ
           # - only for HTTP POST/PATCH
           def validate_request
             return unless request.post? || request.patch?
-            return unless self.class.to_s.split('::').length > 2
+            return unless @@openapi_enabled
 
             api_version = self.class.send(:api_version)[1..-1].sub(/x/, ".")
 

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery :with => :null_session
 
+  include ManageIQ::API::Common::ApplicationControllerMixins::OpenapiEnabled
   include ManageIQ::API::Common::ApplicationControllerMixins::ApiDoc
   include ManageIQ::API::Common::ApplicationControllerMixins::Common
   include ManageIQ::API::Common::ApplicationControllerMixins::RequestBodyValidation

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery :with => :null_session
 
-  include ManageIQ::API::Common::ApplicationControllerMixins::OpenapiEnabled
   include ManageIQ::API::Common::ApplicationControllerMixins::ApiDoc
   include ManageIQ::API::Common::ApplicationControllerMixins::Common
   include ManageIQ::API::Common::ApplicationControllerMixins::RequestBodyValidation


### PR DESCRIPTION
Only openapi specific controllers should get validated with the
openapi json spec.

This uses a class variable at the controller level 
openapi_enabled
to check if we the class supports openapi validation.

For the classes that dont need openapi_validation the developer can set it to false.