### PR TITLE
update_attributes deprecation

### DIFF
--- a/app/models/authentication.rb
+++ b/app/models/authentication.rb
@@ -10,11 +10,7 @@ class Authentication < ActiveRecord::Base
   validates :encryption, :presence => true
 
   def secret=(secret)
-    if encryption.nil?
-      self.encryption = Encryption.new(:secret => secret)
-    else
-      encryption.update_attributes(:secret => secret)
-    end
+    encryption.nil? ? self.encryption = Encryption.new(:secret => secret) : encryption.update(:secret => secret)
   end
 
   def secret

--- a/spec/dummy/db/seeds.rb
+++ b/spec/dummy/db/seeds.rb
@@ -1,10 +1,6 @@
 def update_or_create(model, attributes)
   obj = model.find_by(:name => attributes[:name])
-  if obj
-    obj.update_attributes!(attributes.except(:name))
-  else
-    model.create!(attributes)
-  end
+  obj ? obj.update!(attributes.except(:name)) : model.create!(attributes)
 end
 
 openshift_json_schema = {


### PR DESCRIPTION
update_attributes and update_attributes! are deprecated starting in Rails 6

See https://rubyinrails.com/2019/04/09/rails-6-1-activerecord-deprecates-update-attributes-methods/ for details and Rails PR links

@miq-bot add_label technical debt