### PR TITLE
Default to add ':as => :json' for all patch, post, and put request specs

### DIFF
--- a/spec/requests/request_body_validation_spec.rb
+++ b/spec/requests/request_body_validation_spec.rb
@@ -4,63 +4,67 @@ RSpec.describe "ManageIQ::API::Common::ApplicationController Body", :type => :re
   before { stub_const("ENV", "BYPASS_TENANCY" => true) }
   let(:default_params) { { "authtype" => "openshift" } }
 
-  it "invalid body" do
-    post("/api/v1.0/authentications", :headers => {"CONTENT_TYPE" => "application/text"}, :params => "{")
+  context "when there is an invalid body" do
+    let(:default_as) { :text }
 
-    expect(response.status).to eq(400)
+    it "returns a 400" do
+      post("/api/v1.0/authentications", :headers => {"CONTENT_TYPE" => "application/text"}, :params => "{")
+
+      expect(response.status).to eq(400)
+    end
   end
 
   it "unpermitted key" do
-    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("garbage" => "abc").to_json)
+    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("garbage" => "abc"))
 
     expect(response.status).to eq(400)
     expect(response.parsed_body).to eq("errors" => [{"detail" => "properties garbage are not defined in #/components/schemas/Authentication", "status" => 400}])
   end
 
   it "permitted key, good value" do
-    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("username" => "abc").to_json)
+    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("username" => "abc"))
 
     expect(response.status).to eq(200)
     expect(response.parsed_body).to eq("OK")
   end
 
   it "permitted key, bad value" do
-    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("username" => 1).to_json)
+    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("username" => 1))
 
     expect(response.status).to eq(400)
     expect(response.parsed_body).to eq("errors" => [{"detail" => "1 class is Integer but it's not valid string in #/components/schemas/Authentication/properties/username", "status" => 400}])
   end
 
   it "permitted key, array" do
-    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("array" => [1]).to_json)
+    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("array" => [1]))
 
     expect(response.status).to eq(200)
     expect(response.parsed_body).to eq("OK")
   end
 
   it "permitted key, hash" do
-    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("hash" => {"a" => 1}).to_json)
+    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("hash" => {"a" => 1}))
 
     expect(response.status).to eq(200)
     expect(response.parsed_body).to eq("OK")
   end
 
   it "permitted key, hash nested" do
-    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("hash" => {"a" => {1 => {}}}).to_json)
+    post("/api/v1.0/authentications", :headers => headers, :params => default_params.merge("hash" => {"a" => {1 => {}}}))
 
     expect(response.status).to eq(200)
     expect(response.parsed_body).to eq("OK")
   end
 
   it "required property is missing" do
-    post("/api/v1.0/authentications", :headers => headers, :params => {"username" => "abc"}.to_json)
+    post("/api/v1.0/authentications", :headers => headers, :params => {"username" => "abc"})
 
     expect(response.status).to eq(400)
     expect(response.parsed_body).to eq("errors" => [{"detail" => "required parameters authtype not exist in #/components/schemas/Authentication", "status" => 400}])
   end
 
   it "empty body" do
-    post("/api/v1.0/authentications", :headers => headers, :params => "")
+    post("/api/v1.0/authentications", :headers => headers)
 
     expect(response.status).to eq(400)
     expect(response.parsed_body).to eq("errors" => [{"detail" => "required parameters authtype not exist in #/components/schemas/Authentication", "status" => 400}])

--- a/spec/support/default_as_json.rb
+++ b/spec/support/default_as_json.rb
@@ -1,0 +1,17 @@
+module DefaultAsJson
+  extend ActiveSupport::Concern
+
+  included do
+    let(:default_as) { :json }
+    prepend RequestHelpersCustomized
+  end
+
+  module RequestHelpersCustomized
+    %w[patch post put].each do |method|
+      define_method(method) do |path, **kwargs|
+        kwargs[:as] ||= default_as if default_as
+        super(path, kwargs)
+      end
+    end
+  end
+end

--- a/spec/support/requests_spec_helper.rb
+++ b/spec/support/requests_spec_helper.rb
@@ -1,0 +1,7 @@
+require "support/default_as_json"
+
+module RequestSpecHelper
+  RSpec.configure do |config|
+    config.include DefaultAsJson, :type => :request
+  end
+end


### PR DESCRIPTION
Opening this PR in favor of https://github.com/ManageIQ/catalog-api/pull/369, since it appears that more than just catalog will make use of this spec change.