### PR TITLE
add api error class for use across microservices

### DIFF
--- a/lib/manageiq/api/common.rb
+++ b/lib/manageiq/api/common.rb
@@ -1,3 +1,4 @@
+require "manageiq/api/common/api_error"
 require "manageiq/api/common/engine"
 require "manageiq/api/common/entitlement"
 require "manageiq/api/common/error_document"

--- a/lib/manageiq/api/common/api_error.rb
+++ b/lib/manageiq/api/common/api_error.rb
@@ -1,0 +1,21 @@
+module ManageIQ
+  module API
+    module Common
+      class ApiError < StandardError
+        attr_reader :errors
+
+        def initialize(status, detail)
+          @errors = ErrorDocument.new.add(status, detail)
+        end
+
+        def status
+          @errors.status
+        end
+
+        def add(status, detail)
+          @errors.add(status, detail)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds an exception class that wraps the `ErrorDocument` class so we can use it across catalog/approval so we can be in compliance with the IPP. 