### PR TITLE
Fix require default_as_json to be relative

### DIFF
--- a/spec/support/requests_spec_helper.rb
+++ b/spec/support/requests_spec_helper.rb
@@ -1,4 +1,4 @@
-require "support/default_as_json"
+require_relative "default_as_json"
 
 module RequestSpecHelper
   RSpec.configure do |config|


### PR DESCRIPTION
@bdunne After updating to the latest manageiq-api-common on catalog, specs were failing because the require for the `default_as_json` file was attempting to look in `spec/support` but since that file doesn't exist in the catalog project (or any other project that would use this), it was failing. This should fix that 😄 

/cc @syncrou 