### PR TITLE
Allow use of GraphiQL with enabling the openapi validator

### DIFF
--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -41,7 +41,8 @@ module ManageIQ
                       },
                       "variables"     => {
                         "type"        => "object",
-                        "description" => "Optional Query variables"
+                        "description" => "Optional Query variables",
+                        "nullable"    => true
                       }
                     },
                     "required"   => [


### PR DESCRIPTION
Without this, the GraphiQL app could not be used while enabling the validator on graphql requests.

With this, we don't need the 

```
skip_before_action :validate_request
```

in the GraphQL controllers.
