### PR TITLE
Ignore the query string on id validation

### DIFF
--- a/lib/manageiq/api/common/application_controller_mixins/request_path.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_path.rb
@@ -22,7 +22,10 @@ module ManageIQ
           end
 
           def request_path_parts
-            @request_path_parts ||= request_path.match(/\/(?<full_version_string>v\d+.\d+)\/(?<primary_collection_name>\w+)(\/(?<primary_collection_id>[^\/]+)(\/(?<subcollection_name>\w+))?)?/)&.named_captures || {}
+            @request_path_parts ||= begin
+              path, _query = request_path.split("?")
+              path.match(/\/(?<full_version_string>v\d+.\d+)\/(?<primary_collection_name>\w+)(\/(?<primary_collection_id>[^\/]+)(\/(?<subcollection_name>\w+))?)?/)&.named_captures || {}
+            end
           end
 
           def subcollection?

--- a/spec/lib/manageiq/api/common/application_controller_mixins/request_path_spec.rb
+++ b/spec/lib/manageiq/api/common/application_controller_mixins/request_path_spec.rb
@@ -19,16 +19,17 @@ describe ManageIQ::API::Common::ApplicationControllerMixins::RequestPath do
 
   context "#subcollection?" do
     it "valid paths" do
-      expect(test_class.new("/aaa/bbb/v1.0/primary").subcollection?).to eq(false)
-      expect(test_class.new("/aaa/v1.0/primary").subcollection?).to     eq(false)
-      expect(test_class.new("/v1.0/primary").subcollection?).to         eq(false)
-      expect(test_class.new("/v1.0/primary/").subcollection?).to        eq(false)
-      expect(test_class.new("/v1.0/primary/1").subcollection?).to       eq(false)
-      expect(test_class.new("/v1.0/primary/1/").subcollection?).to      eq(false)
-      expect(test_class.new("/v1.0/primary/1/sub").subcollection?).to   eq(true)
-      expect(test_class.new("/v1.0/primary/1/sub/").subcollection?).to  eq(true)
-      expect(test_class.new("/v1.0/primary/1a/sub").subcollection?).to  eq(true)
-      expect(test_class.new("/v1.0/primary/a_b/sub").subcollection?).to eq(true)
+      expect(test_class.new("/aaa/bbb/v1.0/primary").subcollection?).to    eq(false)
+      expect(test_class.new("/aaa/v1.0/primary").subcollection?).to        eq(false)
+      expect(test_class.new("/v1.0/primary").subcollection?).to            eq(false)
+      expect(test_class.new("/v1.0/primary/").subcollection?).to           eq(false)
+      expect(test_class.new("/v1.0/primary/1").subcollection?).to          eq(false)
+      expect(test_class.new("/v1.0/primary/1?abc=true").subcollection?).to eq(false)
+      expect(test_class.new("/v1.0/primary/1/").subcollection?).to         eq(false)
+      expect(test_class.new("/v1.0/primary/1/sub").subcollection?).to      eq(true)
+      expect(test_class.new("/v1.0/primary/1/sub/").subcollection?).to     eq(true)
+      expect(test_class.new("/v1.0/primary/1a/sub").subcollection?).to     eq(true)
+      expect(test_class.new("/v1.0/primary/a_b/sub").subcollection?).to    eq(true)
     end
 
     it "invalid paths" do
@@ -38,16 +39,17 @@ describe ManageIQ::API::Common::ApplicationControllerMixins::RequestPath do
 
   context "#request_path_parts" do
     it "valid paths" do
-      expect(test_class.new("/aaa/bbb/v1.0/primary").request_path_parts).to eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/aaa/v1.0/primary").request_path_parts).to     eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary").request_path_parts).to         eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary/").request_path_parts).to        eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary/1").request_path_parts).to       eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary/1/").request_path_parts).to      eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => nil)
-      expect(test_class.new("/v1.0/primary/1/sub").request_path_parts).to   eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => "sub")
-      expect(test_class.new("/v1.0/primary/1/sub/").request_path_parts).to  eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => "sub")
-      expect(test_class.new("/v1.0/primary/a_b/sub").request_path_parts).to eq("full_version_string" => "v1.0", "primary_collection_id" => "a_b", "primary_collection_name" => "primary", "subcollection_name" => "sub")
-      expect(test_class.new("/v1.0/primary/1a/sub").request_path_parts).to  eq("full_version_string" => "v1.0", "primary_collection_id" => "1a",  "primary_collection_name" => "primary", "subcollection_name" => "sub")
+      expect(test_class.new("/aaa/bbb/v1.0/primary").request_path_parts).to     eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/aaa/v1.0/primary").request_path_parts).to         eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary").request_path_parts).to             eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary/").request_path_parts).to            eq("full_version_string" => "v1.0", "primary_collection_id" => nil,   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary/1").request_path_parts).to           eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary/1?abc=true").request_path_parts).to  eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary/1/").request_path_parts).to          eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => nil)
+      expect(test_class.new("/v1.0/primary/1/sub").request_path_parts).to       eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => "sub")
+      expect(test_class.new("/v1.0/primary/1/sub/").request_path_parts).to      eq("full_version_string" => "v1.0", "primary_collection_id" => "1",   "primary_collection_name" => "primary", "subcollection_name" => "sub")
+      expect(test_class.new("/v1.0/primary/a_b/sub").request_path_parts).to     eq("full_version_string" => "v1.0", "primary_collection_id" => "a_b", "primary_collection_name" => "primary", "subcollection_name" => "sub")
+      expect(test_class.new("/v1.0/primary/1a/sub").request_path_parts).to      eq("full_version_string" => "v1.0", "primary_collection_id" => "1a",  "primary_collection_name" => "primary", "subcollection_name" => "sub")
     end
 
     it "invalid paths" do


### PR DESCRIPTION
Previously it could be captured as part of the primary_collection_id and cause id validation to fail