### PR TITLE
Enhanced GraphQL parsing of OpenAPI component paths

### DIFF
--- a/lib/manageiq/api/common/graphql/generator.rb
+++ b/lib/manageiq/api/common/graphql/generator.rb
@@ -41,16 +41,19 @@ module ManageIQ
 
           def self.resource_associations(openapi_content, collection)
             collection_is_associated = openapi_content["paths"].keys.any? do |path|
-              path.match("^/[^/]*/{id}/#{collection}$") &&
-                openapi_content.dig("paths", path, "get")
+              path.match?("^/[^/]*/{[[a-z]*_]*id}/#{collection}$") &&
+                openapi_content.dig("paths", path, "get").present?
             end
             collection_associations = []
             openapi_content["paths"].keys.each do |path|
-              subcollection_match = path.match("^/#{collection}/{id}/([^/]*)$")
+              subcollection_match = path.match("^/#{collection}/{[[a-z]*_]*id}/([^/]*)$")
               next unless subcollection_match
 
               subcollection = subcollection_match[1]
-              next unless openapi_content.dig("paths", "/#{subcollection}/{id}", "get")
+              next unless openapi_content["paths"].keys.any? do |subcollection_path|
+                subcollection_path.match?("^/#{subcollection}/{[[a-z]*_]*id}$") &&
+                openapi_content.dig("paths", subcollection_path, "get").present?
+              end
 
               collection_associations << subcollection
             end
@@ -100,7 +103,7 @@ module ManageIQ
             resources.each do |resource|
               next unless openapi_content.dig("paths", resource, "get") # we only care for queries
 
-              rmatch = resource.match("^/(.*/)?([^/]*)/{id}$")
+              rmatch = resource.match("^/(.*/)?([^/]*)/{[[a-z]*_]*id}$")
               next unless rmatch
 
               collection = rmatch[2]

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -263,7 +263,7 @@
         }
       }
     },
-    "/source_types/{id}/sources": {
+    "/source_types/{source_type_id}/sources": {
       "get": {
         "summary": "List Sources for SourceType",
         "operationId": "listSourceTypeSources",
@@ -386,7 +386,7 @@
         }
       }
     },
-    "/sources/{id}/endpoints": {
+    "/sources/{source_id}/endpoints": {
       "get": {
         "summary": "List Endpoints for Source",
         "operationId": "listSourceEndpoints",

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -353,39 +353,6 @@
         }
       }
     },
-    "/sources/{id}/applications": {
-      "get": {
-        "summary": "List Applications for Source",
-        "operationId": "listSourceApplications",
-        "description": "Returns an array of Application objects",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/QueryLimit"
-          },
-          {
-            "$ref": "#/components/parameters/QueryOffset"
-          },
-          {
-            "$ref": "#/components/parameters/QueryFilter"
-          },
-          {
-            "$ref": "#/components/parameters/ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Applications collection",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ApplicationsCollection"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "/sources/{id}/endpoints": {
       "get": {
         "summary": "List Endpoints for Source",
@@ -415,63 +382,6 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "/vms": {
-      "get": {
-        "summary": "List Vms",
-        "operationId": "listVms",
-        "description": "Returns an array of Vm objects",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/QueryLimit"
-          },
-          {
-            "$ref": "#/components/parameters/QueryOffset"
-          },
-          {
-            "$ref": "#/components/parameters/QueryFilter"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Vms collection",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/VmsCollection"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/vms/{id}": {
-      "get": {
-        "summary": "Show an existing Vm",
-        "operationId": "showVm",
-        "description": "Returns a Vm object",
-        "parameters": [
-          {
-            "$ref": "#/components/parameters/ID"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Vm info",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Vm"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not found"
           }
         }
       }
@@ -781,7 +691,10 @@
             "type": "object"
           },
           "array": {
-            "type": "array"
+            "type": "array",
+            "items": {
+              "type" : "integer"
+            }
           }
         }
       },

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -236,14 +236,14 @@
         }
       }
     },
-    "/source_types/{id}": {
+    "/source_types/{source_type_id}": {
       "get": {
         "summary": "Show an existing SourceType",
         "operationId": "showSourceType",
         "description": "Returns a SourceType object",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ID"
+            "$ref": "#/components/parameters/SourceTypeID"
           }
         ],
         "responses": {
@@ -279,7 +279,7 @@
             "$ref": "#/components/parameters/QueryFilter"
           },
           {
-            "$ref": "#/components/parameters/ID"
+            "$ref": "#/components/parameters/SourceTypeID"
           }
         ],
         "responses": {
@@ -386,7 +386,7 @@
         }
       }
     },
-    "/sources/{source_id}/endpoints": {
+    "/sources/{id}/endpoints": {
       "get": {
         "summary": "List Endpoints for Source",
         "operationId": "listSourceEndpoints",
@@ -715,6 +715,16 @@
           "type": "integer",
           "minimum": 0,
           "default": 0
+        }
+      },
+      "SourceTypeID": {
+        "name": "source_type_id",
+        "in": "path",
+        "description": "The Source Type ID",
+        "required": true,
+        "schema": {
+          "type": "string",
+          "pattern": "^\\d+$"
         }
       }
     },


### PR DESCRIPTION
Enhanced the GraphQL schema generator to support other than the {id} references in the paths, namely {anything_id} with a more flexible {[[a-z]*_]*id} match