### PR TITLE
Forward persona header

### DIFF
--- a/lib/manageiq/api/common/request.rb
+++ b/lib/manageiq/api/common/request.rb
@@ -10,7 +10,8 @@ module ManageIQ
       class Request
         REQUEST_ID_KEY = "x-rh-insights-request-id".freeze
         IDENTITY_KEY   = 'x-rh-identity'.freeze
-        FORWARDABLE_HEADER_KEYS = [REQUEST_ID_KEY, IDENTITY_KEY].freeze
+        PERSONA_KEY    = 'x-rh-persona'.freeze
+        FORWARDABLE_HEADER_KEYS = [REQUEST_ID_KEY, IDENTITY_KEY, PERSONA_KEY].freeze
         OPTIONAL_AUTH_PATHS = [
           %r{\A/api/v[0-9]+(\.[0-9]+)?/openapi.json\z},
           %r{\A/api/[^/]+/v[0-9]+(\.[0-9]+)?/openapi.json\z}


### PR DESCRIPTION
A logged in user may have multiple roles, there is need to get resources based on a selected role (persona) instead of all roles. A customized header `x-rh-persona` is used to make such selection. This header is forwardable.