### PR TITLE
Fixes warning with GraphQL schema generator

### DIFF
--- a/lib/manageiq/api/common/graphql/generator.rb
+++ b/lib/manageiq/api/common/graphql/generator.rb
@@ -105,6 +105,8 @@ module ManageIQ
 
               collection = rmatch[2]
               klass_name = collection.camelize.singularize
+              next if graphql_namespace.const_defined?("#{klass_name}Type", false)
+
               _schema_name, this_schema = openapi_schema(openapi_doc, klass_name)
               next if this_schema.nil? || this_schema["type"] != "object" || this_schema["properties"].nil?
 


### PR DESCRIPTION
Fixes warning when GraphQL schema generator tries to redefined  model type already defined.

Fixes #111 

/cc @mkanoor 