### PR TITLE
Add new entitlements: Ansible and Migrations

### DIFF
--- a/lib/manageiq/api/common/entitlement.rb
+++ b/lib/manageiq/api/common/entitlement.rb
@@ -9,8 +9,10 @@ module ManageIQ
         end
 
         %w[
+          ansible
           hybrid_cloud
           insights
+          migrations
           openshift
           smart_management
         ].each do |m|

--- a/spec/lib/manageiq/api/common/entitlements_spec.rb
+++ b/spec/lib/manageiq/api/common/entitlements_spec.rb
@@ -9,7 +9,7 @@ describe ManageIQ::API::Common::Entitlement do
   end
 
   context "entitlement getter methods" do
-    let(:entitlement_keys) { %w[insights openshift hybrid_cloud smart_management] }
+    let(:entitlement_keys) { %w[insights openshift hybrid_cloud smart_management ansible migrations] }
     let(:bad_entitlement)  { %w[fred barney type] }
     let(:entitlement)      { ManageIQ::API::Common::Request.current.entitlement }
     let(:other_user)       { default_user_hash }


### PR DESCRIPTION
You can see current entitlements with:
```
curl https://cloud.redhat.com/api/entitlements/v1/services -u user:password
```

Example output:
```
{"hybrid_cloud":{"is_entitled":true},"insights":{"is_entitled":true},"openshift":{"is_entitled":true},"smart_management":{"is_entitled":true},"ansible":{"is_entitled":false},"migrations":{"is_entitled":true}}
```