### PR TITLE
Prevent first pages from having a "prev" page link

### DIFF
--- a/lib/manageiq/api/common/paginated_response.rb
+++ b/lib/manageiq/api/common/paginated_response.rb
@@ -47,6 +47,7 @@ module ManageIQ
         end
 
         def link_to_prev
+          return if offset == 0
           prev_offset = offset - limit
 
           link_with_new_offset(prev_offset.clamp(0, Float::INFINITY))

--- a/spec/lib/manageiq/api/common/paginated_response_spec.rb
+++ b/spec/lib/manageiq/api/common/paginated_response_spec.rb
@@ -61,7 +61,7 @@ describe ManageIQ::API::Common::PaginatedResponse do
 
       it "first page" do
         expect(described_class.new(base_query: base_query, request: request, limit: 2).send(:links_hash)).to eq(
-          "first" => first_url, "last" => last_url, "next" => url_with_offset(2), "prev" => first_url
+          "first" => first_url, "last" => last_url, "next" => url_with_offset(2)
         )
       end
 
@@ -86,7 +86,7 @@ describe ManageIQ::API::Common::PaginatedResponse do
 
       it "first page" do
         expect(described_class.new(base_query: base_query, request: request, limit: 10).send(:links_hash)).to eq(
-          "first" => first_url, "last" => last_url, "next" => url_with_offset(10), "prev" => first_url
+          "first" => first_url, "last" => last_url, "next" => url_with_offset(10)
         )
       end
 
@@ -117,7 +117,7 @@ describe ManageIQ::API::Common::PaginatedResponse do
 
       it "first page" do
         expect(described_class.new(base_query: base_query, request: request, limit: limit).send(:links_hash)).to eq(
-          "first" => first_url, "last" => last_url, "next" => url_with_offset(3), "prev" => first_url
+          "first" => first_url, "last" => last_url, "next" => url_with_offset(3)
         )
       end
 


### PR DESCRIPTION
Follow-up to #118