### PR TITLE
Added support for sort_by for sorting results.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ After implementing filtering in your application, this is the way to filter via 
 |"?filter[id][]=5&filter[id][]=10&filter[id][]=15&filter[id][]=20"|`{:filter => { :id => ["5", "10", "15", "20"]}}` <br> **`filter: { id: ["5", "10", "15", "20"] }`**|
 |"?filter[id][eq][]=5&filter[id][eq][]=10&filter[id][eq][]=15&filter[id][eq][]=20"|`{:filter => { :id => { :eq => ["5", "10", "15", "20"]}}}` <br> **`filter: { id: { eq: ["5", "10", "15", "20"] }`**|
 
+#### Sorting Results
+
+Sorting query results is controlled via the _sort_by_ query parameter. The _sort_by_ parameter is available for both REST API and GraphQL requests.
+
+The syntax for the _sort_by_ parameter supports:
+
+- a single string representing the attribute name to sort by which may be followed by :asc or :desc
+  - **attribute**   (_default order is ascending_)
+  - **attribute:asc** (_ascending order_)
+  - **attribute:desc** (_descending order_)
+- an array of strings of the above syntax
+
+##### Sort_by Examples:
+
+- GET /api/v1.0/sources?sort_by=name
+- GET /api/v1.0/vms?sort_by[]=power_state\&sort_by[]=memory:desc
+
+| Query Parameter | Ruby Client Parameter | GraphQL Parameter |
+| --------------- | --------------------- | ----------------- |
+| "?sort_by=name" | { :sort_by => "name" } | sort_by: "name" |
+| "?sort_by[]=power_state\&sort_by[]=memory:desc" | { :sort_by => ["power_state", "memory:desc"] } |  sort_by: ["power_state, "memory:desc"] |
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/manageiq/api/common/application_controller_mixins/parameters.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/parameters.rb
@@ -17,7 +17,7 @@ module ManageIQ
           def safe_params_for_list
             check_if_openapi_enabled
             # :limit & :offset can be passed in for pagination purposes, but shouldn't show up as params for filtering purposes
-            @safe_params_for_list ||= params.merge(params_for_polymorphic_subcollection).permit(*permitted_params, :filter => {})
+            @safe_params_for_list ||= params.merge(params_for_polymorphic_subcollection).permit(*permitted_params, :filter => {}, :sort_by => [])
           end
 
           def permitted_params
@@ -96,6 +96,10 @@ module ManageIQ
 
           def pagination_offset
             safe_params_for_list[:offset]
+          end
+
+          def query_sort_by
+            safe_params_for_list[:sort_by]
           end
 
           def params_for_update

--- a/lib/manageiq/api/common/application_controller_mixins/parameters.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/parameters.rb
@@ -22,7 +22,7 @@ module ManageIQ
 
           def permitted_params
             check_if_openapi_enabled
-            api_doc_definition.all_attributes + [:limit, :offset] + [subcollection_foreign_key]
+            api_doc_definition.all_attributes + [:limit, :offset, :sort_by] + [subcollection_foreign_key]
           end
 
           def subcollection_foreign_key

--- a/lib/manageiq/api/common/application_controller_mixins/request_parameter_validation.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_parameter_validation.rb
@@ -14,7 +14,7 @@ module ManageIQ
           def validate_request_parameters
             api_version = self.class.send(:api_version)[1..-1].sub(/x/, ".")
 
-            self.class.send(:api_doc).try(
+            api_doc.try(
               :validate_parameters!,
               request.method,
               request.path,

--- a/lib/manageiq/api/common/application_controller_mixins/request_parameter_validation.rb
+++ b/lib/manageiq/api/common/application_controller_mixins/request_parameter_validation.rb
@@ -1,0 +1,29 @@
+module ManageIQ
+  module API
+    module Common
+      module ApplicationControllerMixins
+        module RequestParameterValidation
+          def self.included(other)
+            other.include(OpenapiEnabled)
+
+            other.before_action(:validate_request_parameters)
+          end
+
+          private
+
+          def validate_request_parameters
+            api_version = self.class.send(:api_version)[1..-1].sub(/x/, ".")
+
+            self.class.send(:api_doc).try(
+              :validate_parameters!,
+              request.method,
+              request.path,
+              api_version,
+              params.slice(:sort_by)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/api/common/graphql.rb
+++ b/lib/manageiq/api/common/graphql.rb
@@ -8,6 +8,7 @@ require "manageiq/api/common/graphql/generator"
 require "manageiq/api/common/graphql/types/big_int"
 require "manageiq/api/common/graphql/types/date_time"
 require "manageiq/api/common/graphql/types/query_filter"
+require "manageiq/api/common/graphql/types/query_sort_by"
 
 module ManageIQ
   module API

--- a/lib/manageiq/api/common/graphql/templates/query_type.erb
+++ b/lib/manageiq/api/common/graphql/templates/query_type.erb
@@ -18,10 +18,12 @@ QueryType = ::GraphQL::ObjectType.define do
       description "List available #{collection}"
       type types[resource_type]
 
-      argument :id, types.ID
-      argument :offset, types.Int, "The number of #{collection} to skip before starting to collect the result set"
-      argument :limit,  types.Int, "The number of #{collection} to return"
-      argument :filter, ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the #{collection}"
+      argument :id,      types.ID
+      argument :offset,  types.Int, "The number of #{collection} to skip before starting to collect the result set"
+      argument :limit,   types.Int, "The number of #{collection} to return"
+      argument :filter,  ::ManageIQ::API::Common::GraphQL::Types::QueryFilter, "The Query Filter for querying the #{collection}"
+      argument :sort_by, ::ManageIQ::API::Common::GraphQL::Types::QuerySortBy, "The optional attributes to sort by. Provided as an array of attr[:asc] and attr:desc values"
+
       resolve lambda { |_obj, args, ctx|
         if base_query.present?
           scope = base_query.call(model_class, ctx)
@@ -39,7 +41,7 @@ QueryType = ::GraphQL::ObjectType.define do
         end
         scope = ::ManageIQ::API::Common::GraphQL.search_options(scope, args)
         ::ManageIQ::API::Common::PaginatedResponse.new(
-          base_query: scope, request: nil, limit: args[:limit], offset: args[:offset]
+          base_query: scope, request: nil, limit: args[:limit], offset: args[:offset], sort_by: args[:sort_by]
         ).records
       }
     end

--- a/lib/manageiq/api/common/graphql/types/query_sort_by.rb
+++ b/lib/manageiq/api/common/graphql/types/query_sort_by.rb
@@ -1,0 +1,16 @@
+module ManageIQ
+  module API
+    module Common
+      module GraphQL
+        module Types
+          QuerySortBy = ::GraphQL::ScalarType.define do
+            name "QuerySortBy"
+            description "The Query SortBy"
+
+            coerce_input ->(value, _ctx) { JSON.parse(value.to_json) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/manageiq/api/common/open_api/docs/doc_v3.rb
+++ b/lib/manageiq/api/common/open_api/docs/doc_v3.rb
@@ -34,6 +34,16 @@ module ManageIQ
               request_operation.validate_request_body(payload_content_type, payload)
             end
 
+            def validate_parameters!(http_method, request_path, api_version, params)
+              path = request_path.split(api_version)[1]
+              raise "API version not found in request_path" if path.nil?
+
+              request_operation = validator_doc.request_operation(http_method.to_s.downcase, path)
+              return unless request_operation
+
+              request_operation.validate_request_parameter(params, {})
+            end
+
             def version
               @version ||= Gem::Version.new(content.fetch_path("info", "version"))
             end

--- a/lib/manageiq/api/common/open_api/generator.rb
+++ b/lib/manageiq/api/common/open_api/generator.rb
@@ -97,6 +97,11 @@ module ManageIQ
                 "pattern"     => "^\\d+$",
                 "readOnly"    => true,
               },
+              "SortByAttribute"    => {
+                "type"        => "string",
+                "description" => "Attribute with optional order to sort the result set by.",
+                "pattern"     => "^[a-z-_]+(:asc|:desc)?$"
+              }
             }
           end
 
@@ -169,6 +174,18 @@ module ManageIQ
                   "default" => 0
                 }
               },
+              "QuerySortBy" => {
+                "in"          => "query",
+                "name"        => "sort_by",
+                "description" => "The list of attribute and order to sort the result set by.",
+                "required"    => false,
+                "schema"      => {
+                  "oneOf" => [
+                    { "$ref" => "##{SCHEMAS_PATH}/SortByAttribute" },
+                    { "type" => "array", "items" => { "$ref" => "##{SCHEMAS_PATH}/SortByAttribute" } }
+                  ]
+                }
+              }
             }
           end
 
@@ -194,7 +211,8 @@ module ManageIQ
               "parameters"  => [
                 { "$ref" => "##{PARAMETERS_PATH}/QueryLimit"  },
                 { "$ref" => "##{PARAMETERS_PATH}/QueryOffset" },
-                { "$ref" => "##{PARAMETERS_PATH}/QueryFilter" }
+                { "$ref" => "##{PARAMETERS_PATH}/QueryFilter" },
+                { "$ref" => "##{PARAMETERS_PATH}/QuerySortBy" }
               ],
               "responses"   => {
                 "200" => {

--- a/lib/manageiq/api/common/open_api/generator.rb
+++ b/lib/manageiq/api/common/open_api/generator.rb
@@ -100,7 +100,7 @@ module ManageIQ
               "SortByAttribute"    => {
                 "type"        => "string",
                 "description" => "Attribute with optional order to sort the result set by.",
-                "pattern"     => "^[a-z-_]+(:asc|:desc)?$"
+                "pattern"     => "^[a-z\\-_]+(:asc|:desc)?$"
               }
             }
           end

--- a/spec/dummy/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/spec/dummy/app/controllers/api/v1/mixins/index_mixin.rb
@@ -8,7 +8,8 @@ module Api
             :base_query => scoped(filtered.where(params_for_list)),
             :request    => request,
             :limit      => pagination_limit,
-            :offset     => pagination_offset
+            :offset     => pagination_offset,
+            :sort_by    => query_sort_by
           ).response
         end
 

--- a/spec/dummy/app/controllers/api/v1/source_types_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/source_types_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class SourceTypesController < ApplicationController
+      include Api::V1::Mixins::IndexMixin
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -64,5 +64,6 @@ module Api
 
     class GraphqlController < Api::V1::GraphqlController; end
     class SourcesController < Api::V1::SourcesController; end
+    class SourceTypesController < Api::V1::SourceTypesController; end
   end
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -6,5 +6,6 @@ class ApplicationController < ActionController::Base
   include ManageIQ::API::Common::ApplicationControllerMixins::ExceptionHandling
   include ManageIQ::API::Common::ApplicationControllerMixins::Parameters
   include ManageIQ::API::Common::ApplicationControllerMixins::RequestBodyValidation
+  include ManageIQ::API::Common::ApplicationControllerMixins::RequestParameterValidation
   include ManageIQ::API::Common::ApplicationControllerMixins::RequestPath
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       resources :vms, :only => [:index, :show]
       resources :persons, :only => [:index, :create, :show, :update]
       resources :sources, :only => [:index]
+      resources :source_types, :only => [:index]
       resources :extras, :only => [:index]
     end
 

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -894,7 +894,7 @@
       "SortByAttribute": {
         "type": "string",
         "description": "Attribute with optional order to sort the result set by.",
-        "pattern": "^[a-z-_]+(:asc|:desc)?$"
+        "pattern": "^[a-z\\-_]+(:asc|:desc)?$"
       },
       "Source": {
         "type": "object",

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -34,6 +34,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -119,6 +122,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -178,6 +184,9 @@
             "$ref": "#/components/parameters/QueryFilter"
           },
           {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -220,6 +229,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -279,6 +291,9 @@
             "$ref": "#/components/parameters/QueryFilter"
           },
           {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
             "$ref": "#/components/parameters/SourceTypeID"
           }
         ],
@@ -310,6 +325,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -369,6 +387,9 @@
             "$ref": "#/components/parameters/QueryFilter"
           },
           {
+            "$ref": "#/components/parameters/QuerySortBy"
+          },
+          {
             "$ref": "#/components/parameters/ID"
           }
         ],
@@ -400,6 +421,9 @@
           },
           {
             "$ref": "#/components/parameters/QueryFilter"
+          },
+          {
+            "$ref": "#/components/parameters/QuerySortBy"
           }
         ],
         "responses": {
@@ -605,6 +629,18 @@
           "type": "integer",
           "minimum": 0,
           "default": 0
+        }
+      },
+      "QuerySortBy": {
+        "in": "query",
+        "name": "sort_by",
+        "description": "The list of attribute and order to sort the result set by.",
+        "required": false,
+        "schema": {
+          "oneOf": [
+            { "$ref": "#/components/schemas/SortByAttribute" },
+            { "type": "array", "items": { "$ref": "#/components/schemas/SortByAttribute" } }
+          ]
         }
       },
       "SourceTypeID": {
@@ -854,6 +890,11 @@
             "description": "The provider specific parameters needed to provision this service. This might include namespaces, special keys"
           }
         }
+      },
+      "SortByAttribute": {
+        "type": "string",
+        "description": "Attribute with optional order to sort the result set by.",
+        "pattern": "^[a-z-_]+(:asc|:desc)?$"
       },
       "Source": {
         "type": "object",

--- a/spec/requests/api/graphql_spec.rb
+++ b/spec/requests/api/graphql_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe ManageIQ::API::Common::GraphQL, :type => :request do
   let!(:identity)     { Base64.encode64({'identity' => { 'account_number' => ext_tenant }}.to_json) }
   let!(:headers)      { { "CONTENT_TYPE" => "application/json", "x-rh-identity" => identity } }
 
-  let!(:source_typeR) { SourceType.create(:name => "rhev", :product_name => "RedHat Virtualization", :vendor => "redhat") }
-  let!(:source_typeV) { SourceType.create(:name => "vmware", :product_name => "VmWare vCenter", :vendor => "vmware") }
-  let!(:source_typeO) { SourceType.create(:name => "openstack", :product_name => "OpenStack", :vendor => "redhat") }
+  let!(:source_typeR) { SourceType.create(:name => "rhev_sample", :product_name => "RedHat Virtualization", :vendor => "redhat") }
+  let!(:source_typeV) { SourceType.create(:name => "vmware_sample", :product_name => "VmWare vCenter", :vendor => "vmware") }
+  let!(:source_typeO) { SourceType.create(:name => "openstack_sample", :product_name => "OpenStack", :vendor => "redhat") }
 
   let!(:source_a1)    { Source.create!(:tenant => tenant, :uid => "1", :name => "source_a1", :source_type => source_typeR) }
   let!(:source_a2)    { Source.create!(:tenant => tenant, :uid => "2", :name => "source_a2", :source_type => source_typeR) }
@@ -225,7 +225,7 @@ RSpec.describe ManageIQ::API::Common::GraphQL, :type => :request do
     it "via sort_by with a single attribute" do
       post(graphql_endpoint, :headers => headers, :params => { "query" => '
         {
-          source_types(sort_by: "vendor") {
+          source_types(filter: { name: { ends_with: "sample" } }, sort_by: "vendor") {
             vendor
           }
         }' })
@@ -238,7 +238,7 @@ RSpec.describe ManageIQ::API::Common::GraphQL, :type => :request do
     it "via sort_by with a single attribute in descending order" do
       post(graphql_endpoint, :headers => headers, :params => { "query" => '
         {
-          source_types(sort_by: "vendor:desc") {
+          source_types(filter: { name: { ends_with: "sample" } }, sort_by: "vendor:desc") {
             vendor
           }
         }' })
@@ -251,7 +251,7 @@ RSpec.describe ManageIQ::API::Common::GraphQL, :type => :request do
     it "via sort_by with a multiple attributes in mixed order" do
       post(graphql_endpoint, :headers => headers, :params => { "query" => '
         {
-          source_types(sort_by: ["vendor", "product_name:desc"]) {
+          source_types(filter: { name: { ends_with: "sample" } }, sort_by: ["vendor", "product_name:desc"]) {
             vendor
             product_name
           }
@@ -491,7 +491,7 @@ RSpec.describe ManageIQ::API::Common::GraphQL, :type => :request do
     it "honors 2-level associations" do
       post(graphql_endpoint, :headers => headers, :params => { "query" => '
         {
-          source_types(filter: {name: {eq: ["rhev", "vmware"]}}) {
+          source_types(filter: {name: {eq: ["rhev_sample", "vmware_sample"]}}) {
             vendor
             product_name
             sources {

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -71,12 +71,12 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
   end
 
   context "sorted results via sort_by" do
-    let!(:rhev)      { SourceType.create(:name => "rhev", :product_name => "RedHat Virtualization", :vendor => "redhat") }
-    let!(:openstack) { SourceType.create(:name => "openstack", :product_name => "OpenStack", :vendor => "redhat") }
-    let!(:vmware)    { SourceType.create(:name => "vmware", :product_name => "OpenStack", :vendor => "vmware") }
+    let!(:rhev)      { SourceType.create(:name => "rhev_sample", :product_name => "RedHat Virtualization", :vendor => "redhat") }
+    let!(:openstack) { SourceType.create(:name => "openstack_sample", :product_name => "OpenStack", :vendor => "redhat") }
+    let!(:vmware)    { SourceType.create(:name => "vmware_sample", :product_name => "OpenStack", :vendor => "vmware") }
 
     it("with single attribute and default order") do
-      expect_success_ordered_objects("sort_by[]=vendor",
+      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by=vendor",
                                      [
                                        {:vendor => "redhat"},
                                        {:vendor => "redhat"},
@@ -85,7 +85,7 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     end
 
     it("with single attribute and order") do
-      expect_success_ordered_objects("sort_by[]=vendor:desc",
+      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by=vendor:desc",
                                      [
                                        {:vendor => "vmware"},
                                        {:vendor => "redhat"},
@@ -94,29 +94,29 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     end
 
     it("with multiple attributes and default order") do
-      expect_success_ordered_objects("sort_by[]=vendor&sort_by[]=name",
+      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by[]=vendor&sort_by[]=name",
                                      [
-                                       {:vendor => "redhat", :name => "openstack"},
-                                       {:vendor => "redhat", :name => "rhev"},
-                                       {:vendor => "vmware", :name => "vmware"}
+                                       {:vendor => "redhat", :name => "openstack_sample"},
+                                       {:vendor => "redhat", :name => "rhev_sample"},
+                                       {:vendor => "vmware", :name => "vmware_sample"}
                                      ])
     end
 
     it("with multiple attributes and only some with order") do
-      expect_success_ordered_objects("sort_by[]=vendor:desc&sort_by[]=name",
+      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by[]=vendor:desc&sort_by[]=name",
                                      [
-                                       {:vendor => "vmware", :name => "vmware"},
-                                       {:vendor => "redhat", :name => "openstack"},
-                                       {:vendor => "redhat", :name => "rhev"},
+                                       {:vendor => "vmware", :name => "vmware_sample"},
+                                       {:vendor => "redhat", :name => "openstack_sample"},
+                                       {:vendor => "redhat", :name => "rhev_sample"},
                                      ])
     end
 
     it("with multiple attributes and all with order") do
-      expect_success_ordered_objects("sort_by[]=vendor:asc&sort_by[]=name:desc",
+      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by[]=vendor:asc&sort_by[]=name:desc",
                                      [
-                                       {:vendor => "redhat", :name => "rhev"},
-                                       {:vendor => "redhat", :name => "openstack"},
-                                       {:vendor => "vmware", :name => "vmware"}
+                                       {:vendor => "redhat", :name => "rhev_sample"},
+                                       {:vendor => "redhat", :name => "openstack_sample"},
+                                       {:vendor => "vmware", :name => "vmware_sample"}
                                      ])
     end
   end

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -36,9 +36,10 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
 
     expect(response.status).to(eq(200))
 
-    response.parsed_body["data"].each do |object|
-      expect(object).to(include(results.shift.deep_stringify_keys))
-    end
+    results = results.collect(&:stringify_keys)
+    attrs = results.first.keys
+
+    expect(response.parsed_body["data"].collect { |res| res.slice(*attrs) }).to(eq(results))
   end
 
   context "case insensitive strings" do

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     Source.create!(attrs.merge(:tenant => tenant, :source_type => source_type))
   end
 
-  def expect_success(query, *results)
-    get(URI.escape("/api/v1.0/sources?#{query}"))
+  def expect_success(collection, query, *results)
+    get(URI.escape("/api/v1.0/#{collection}?#{query}"))
 
     expect(response).to(
       have_attributes(
@@ -18,8 +18,21 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     )
   end
 
-  def expect_success_ordered_objects(query, results)
-    get(URI.escape("/api/v1.0/source_types?#{query}"))
+  def expect_failure(collection, query, *errors)
+    get(URI.escape("/api/v1.0/#{collection}?#{query}"))
+
+    expect(response).to(
+      have_attributes(
+        :parsed_body => {
+          "errors" => errors.collect { |e| {"detail" => e, "status" => 400} }
+        },
+        :status      => 400
+      )
+    )
+  end
+
+  def expect_success_ordered_objects(collection, query, results)
+    get(URI.escape("/api/v1.0/#{collection}?#{query}"))
 
     expect(response.status).to(eq(200))
 
@@ -38,36 +51,36 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     let!(:source_7) { create_source(:name => "Source_f%") }
     let!(:source_8) { create_source(:name => "Source_F%") }
 
-    it("key:eq single")         { expect_success("filter[name][eq]=#{source_1.name}", source_1) }
-    it("key:eq array")          { expect_success("filter[name][eq][]=#{source_1.name}&filter[name][eq][]=#{source_3.name}", source_1, source_3) }
+    it("key:eq single")          { expect_success("sources", "filter[name][eq]=#{source_1.name}", source_1) }
+    it("key:eq array")           { expect_success("sources", "filter[name][eq][]=#{source_1.name}&filter[name][eq][]=#{source_3.name}", source_1, source_3) }
 
-    it("key:eq_i single")        { expect_success("filter[name][eq_i]=#{source_1.name}", source_1, source_2) }
-    it("key:eq_i array")         { expect_success("filter[name][eq_i][]=#{source_1.name}&filter[name][eq_i][]=#{source_3.name}", source_1, source_2, source_3, source_4) }
+    it("key:eq_i single")        { expect_success("sources", "filter[name][eq_i]=#{source_1.name}", source_1, source_2) }
+    it("key:eq_i array")         { expect_success("sources", "filter[name][eq_i][]=#{source_1.name}&filter[name][eq_i][]=#{source_3.name}", source_1, source_2, source_3, source_4) }
 
-    it("key:contains_i single")  { expect_success("filter[name][contains_i]=a", source_1, source_2) }
-    it("key:contains_i array")   { expect_success("filter[name][contains_i][]=s&filter[name][contains_i][]=a", source_1, source_2) }
+    it("key:contains_i single")  { expect_success("sources", "filter[name][contains_i]=a", source_1, source_2) }
+    it("key:contains_i array")   { expect_success("sources", "filter[name][contains_i][]=s&filter[name][contains_i][]=a", source_1, source_2) }
 
-    it("key:starts_with_i")      { expect_success("filter[name][starts_with_i]=s", source_1, source_2, source_3, source_4, source_7, source_8) }
+    it("key:starts_with_i")      { expect_success("sources", "filter[name][starts_with_i]=s", source_1, source_2, source_3, source_4, source_7, source_8) }
 
-    it("key:ends_with_i")        { expect_success("filter[name][ends_with_i]=b", source_3, source_4) }
+    it("key:ends_with_i")        { expect_success("sources", "filter[name][ends_with_i]=b", source_3, source_4) }
 
-    it("key:starts_with")      { expect_success("filter[name][starts_with]=source", source_1, source_3) }
+    it("key:starts_with")        { expect_success("sources", "filter[name][starts_with]=source", source_1, source_3) }
 
-    it("key:ends_with")        { expect_success("filter[name][ends_with]=b", source_3) }
+    it("key:ends_with")          { expect_success("sources", "filter[name][ends_with]=b", source_3) }
 
-    it("key:starts_with_i %")    { expect_success("filter[name][starts_with_i]=%s", source_5, source_6) }
-    it("key:ends_with_i %")      { expect_success("filter[name][ends_with_i]=f%", source_7, source_8) }
+    it("key:starts_with_i %")    { expect_success("sources", "filter[name][starts_with_i]=%s", source_5, source_6) }
+    it("key:ends_with_i %")      { expect_success("sources", "filter[name][ends_with_i]=f%", source_7, source_8) }
 
-    it("key:eq array")           { expect_success("filter[id][]=#{source_7.id}&filter[id][]=#{source_8.id}", source_7, source_8) }
-    it("key:eq(explicit) array") { expect_success("filter[id][eq][]=#{source_7.id}&filter[id][eq][]=#{source_8.id}", source_7, source_8) }
+    it("key:eq array")           { expect_success("sources", "filter[id][]=#{source_7.id}&filter[id][]=#{source_8.id}", source_7, source_8) }
+    it("key:eq(explicit) array") { expect_success("sources", "filter[id][eq][]=#{source_7.id}&filter[id][eq][]=#{source_8.id}", source_7, source_8) }
 
-    it("key:gt")                 { expect_success("filter[id][gt]=#{source_1.id}", *Source.where(Source.arel_table[:id].gt(source_1.id))) }
+    it("key:gt")                 { expect_success("sources", "filter[id][gt]=#{source_1.id}", *Source.where(Source.arel_table[:id].gt(source_1.id))) }
 
-    it("key:gte")                { expect_success("filter[id][gte]=#{source_1.id}", *Source.where(Source.arel_table[:id].gteq(source_1.id))) }
+    it("key:gte")                { expect_success("sources", "filter[id][gte]=#{source_1.id}", *Source.where(Source.arel_table[:id].gteq(source_1.id))) }
 
-    it("key:lt")                 { expect_success("filter[id][lt]=#{source_8.id}", *Source.where(Source.arel_table[:id].lt(source_8.id))) }
+    it("key:lt")                 { expect_success("sources", "filter[id][lt]=#{source_8.id}", *Source.where(Source.arel_table[:id].lt(source_8.id))) }
 
-    it("key:lte")                { expect_success("filter[id][lte]=#{source_8.id}", *Source.where(Source.arel_table[:id].lteq(source_8.id))) }
+    it("key:lte")                { expect_success("sources", "filter[id][lte]=#{source_8.id}", *Source.where(Source.arel_table[:id].lteq(source_8.id))) }
   end
 
   context "sorted results via sort_by" do
@@ -76,7 +89,7 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     let!(:vmware)    { SourceType.create(:name => "vmware_sample", :product_name => "OpenStack", :vendor => "vmware") }
 
     it("with single attribute and default order") do
-      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by=vendor",
+      expect_success_ordered_objects("source_types", "filter[name][ends_with]=sample&sort_by=vendor",
                                      [
                                        {:vendor => "redhat"},
                                        {:vendor => "redhat"},
@@ -85,7 +98,7 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     end
 
     it("with single attribute and order") do
-      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by=vendor:desc",
+      expect_success_ordered_objects("source_types", "filter[name][ends_with]=sample&sort_by=vendor:desc",
                                      [
                                        {:vendor => "vmware"},
                                        {:vendor => "redhat"},
@@ -94,7 +107,7 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     end
 
     it("with multiple attributes and default order") do
-      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by[]=vendor&sort_by[]=name",
+      expect_success_ordered_objects("source_types", "filter[name][ends_with]=sample&sort_by[]=vendor&sort_by[]=name",
                                      [
                                        {:vendor => "redhat", :name => "openstack_sample"},
                                        {:vendor => "redhat", :name => "rhev_sample"},
@@ -103,7 +116,7 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     end
 
     it("with multiple attributes and only some with order") do
-      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by[]=vendor:desc&sort_by[]=name",
+      expect_success_ordered_objects("source_types", "filter[name][ends_with]=sample&sort_by[]=vendor:desc&sort_by[]=name",
                                      [
                                        {:vendor => "vmware", :name => "vmware_sample"},
                                        {:vendor => "redhat", :name => "openstack_sample"},
@@ -112,12 +125,36 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     end
 
     it("with multiple attributes and all with order") do
-      expect_success_ordered_objects("filter[name][ends_with]=sample&sort_by[]=vendor:asc&sort_by[]=name:desc",
+      expect_success_ordered_objects("source_types", "filter[name][ends_with]=sample&sort_by[]=vendor:asc&sort_by[]=name:desc",
                                      [
                                        {:vendor => "redhat", :name => "rhev_sample"},
                                        {:vendor => "redhat", :name => "openstack_sample"},
                                        {:vendor => "vmware", :name => "vmware_sample"}
                                      ])
+    end
+
+    it("returns a bad_request if the single sort_by attribute is illegal") do
+      expect_failure("source_types", "sort_by=Capital^#", "OpenAPIParser::NotOneOf: Capital^# isn't one of in #/components/parameters/QuerySortBy/schema")
+    end
+
+    it("returns a bad_request if the single sort_by attribute order is missing") do
+      expect_failure("source_types", "sort_by=name:", "OpenAPIParser::NotOneOf: name: isn't one of in #/components/parameters/QuerySortBy/schema")
+    end
+
+    it("returns a bad_request if the single sort_by attribute order is invalid") do
+      expect_failure("source_types", "sort_by=name:bogus", "OpenAPIParser::NotOneOf: name:bogus isn't one of in #/components/parameters/QuerySortBy/schema")
+    end
+
+    it("returns a bad_request one of the multiple sort_by attributes is malformed") do
+      expect_failure("source_types", "sort_by[]=Capital^#", "OpenAPIParser::NotOneOf: [\"Capital^#\"] isn't one of in #/components/parameters/QuerySortBy/schema")
+    end
+
+    it("returns a bad_request if the single sort_by attribute order is missing") do
+      expect_failure("source_types", "sort_by[]=name&sort_by[]=vendor:", "OpenAPIParser::NotOneOf: [\"name\", \"vendor:\"] isn't one of in #/components/parameters/QuerySortBy/schema")
+    end
+
+    it("returns a bad_request if the single sort_by attribute order is invalid") do
+      expect_failure("source_types", "sort_by[]=name&sort_by[]=vendor:bogus", "OpenAPIParser::NotOneOf: [\"name\", \"vendor:bogus\"] isn't one of in #/components/parameters/QuerySortBy/schema")
     end
   end
 end


### PR DESCRIPTION
Added support for sort_by for sorting results.

- Supports a single string representing an attribute, attribute:asc or attribute:desc
- Supports array of attribute, attribute:asc and attribute:desc

Examples:

URL Query:
- GET /api/v1.0/sources?sort_by=name
- GET /api/v1.0/vms?sort_by[]=power_state&sort_by[]=memory:desc

Ruby Client Parameter:
- :sort_by => "name"
- :sort_by => ["power_state", "memory:desc"]

GraphQL Parameter:
- sort_by: "name"
- sort_by: ["power_state, "memory:desc"]


GraphQL Example:

```
{
  sources(sort_by: ["source_type_id:asc", "uid:desc"]) {
    source_type_id
    id
    name
    uid
  }
}
```

Or as simple as:

```
{
  sources(sort_by: "name") {
    id
    name
  }
}
```

Enhancement as per TPINVTRY-705
