### PR TITLE
Adding support for case insensitive searches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ Or install it yourself as:
 
 #### ManageIQ::Api::Common::Filter
 
+| Supported Comparators     | Comparator    |
+| ---------------------     | ----------    |
+| Integer                   | eq            |
+|                           | gt            |
+|                           | gte           |
+|                           | lt            |
+|                           | lte           |
+|                           | nil           |
+|                           | not_nil       |
+| String                    | eq            |
+|                           | contains      |
+|                           | starts_with   |
+|                           | ends_with     |
+|                           | nil           |
+|                           | not_nil       |
+| String (case insensitive) | eq_i          |
+|                           | contains_i    |
+|                           | starts_with_i |
+|                           | ends_with_i   |
+
 After implementing filtering in your application, this is the way to filter via parameters on index functions:
 
 | Query Parameter | Ruby Client Parameter <br> **GraphQL filter: Parameter** |

--- a/lib/manageiq/api/common/filter.rb
+++ b/lib/manageiq/api/common/filter.rb
@@ -3,7 +3,7 @@ module ManageIQ
     module Common
       class Filter
         INTEGER_COMPARISON_KEYWORDS = ["eq", "gt", "gte", "lt", "lte", "nil", "not_nil"].freeze
-        STRING_COMPARISON_KEYWORDS  = ["contains", "eq", "starts_with", "ends_with", "nil", "not_nil"].freeze
+        STRING_COMPARISON_KEYWORDS  = ["contains", "contains_i", "eq", "eq_i", "starts_with", "starts_with_i", "ends_with", "ends_with_i", "nil", "not_nil"].freeze
 
         attr_reader :apply, :arel_table, :api_doc_definition
 
@@ -116,19 +116,38 @@ module ManageIQ
 
         def comparator_contains(key, value)
           return value.each { |v| comparator_contains(key, v) } if value.kind_of?(Array)
+
           self.query = query.where(arel_table[key].matches("%#{query.sanitize_sql_like(value)}%", nil, true))
+        end
+
+        def comparator_contains_i(key, value)
+          return value.each { |v| comparator_contains_i(key, v) } if value.kind_of?(Array)
+
+          self.query = query.where(arel_table[key].lower.matches("%#{query.sanitize_sql_like(value.downcase)}%", nil, true))
         end
 
         def comparator_starts_with(key, value)
           self.query = query.where(arel_table[key].matches("#{query.sanitize_sql_like(value)}%", nil, true))
         end
 
+        def comparator_starts_with_i(key, value)
+          self.query = query.where(arel_table[key].lower.matches("#{query.sanitize_sql_like(value.downcase)}%", nil, true))
+        end
+
         def comparator_ends_with(key, value)
           self.query = query.where(arel_table[key].matches("%#{query.sanitize_sql_like(value)}", nil, true))
         end
 
+        def comparator_ends_with_i(key, value)
+          self.query = query.where(arel_table[key].lower.matches("%#{query.sanitize_sql_like(value.downcase)}", nil, true))
+        end
+
         def comparator_eq(key, value)
           self.query = query.where(key => value)
+        end
+
+        def comparator_eq_i(key, value)
+          self.query = query.where(arel_table[key].lower.eq(value.downcase))
         end
 
         def comparator_gt(key, value)

--- a/lib/manageiq/api/common/filter.rb
+++ b/lib/manageiq/api/common/filter.rb
@@ -147,7 +147,9 @@ module ManageIQ
         end
 
         def comparator_eq_i(key, value)
-          self.query = query.where(arel_table[key].lower.eq(value.downcase))
+          values = Array(value).map { |v| query.sanitize_sql_like(v.downcase) }
+
+          self.query = query.where(arel_table[key].lower.matches_any(values))
         end
 
         def comparator_gt(key, value)

--- a/spec/dummy/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/spec/dummy/app/controllers/api/v1/mixins/index_mixin.rb
@@ -4,11 +4,11 @@ module Api
       module IndexMixin
         def index
           raise_unless_primary_instance_exists
-          render json: ManageIQ::API::Common::PaginatedResponse.new(
-            base_query: scoped(filtered.where(params_for_list)),
-            request: request,
-            limit: pagination_limit,
-            offset: pagination_offset
+          render :json => ManageIQ::API::Common::PaginatedResponse.new(
+            :base_query => scoped(filtered.where(params_for_list)),
+            :request    => request,
+            :limit      => pagination_limit,
+            :offset     => pagination_offset
           ).response
         end
 

--- a/spec/dummy/app/controllers/api/v1/mixins/index_mixin.rb
+++ b/spec/dummy/app/controllers/api/v1/mixins/index_mixin.rb
@@ -1,0 +1,32 @@
+module Api
+  module V1
+    module Mixins
+      module IndexMixin
+        def index
+          raise_unless_primary_instance_exists
+          render json: ManageIQ::API::Common::PaginatedResponse.new(
+            base_query: scoped(filtered.where(params_for_list)),
+            request: request,
+            limit: pagination_limit,
+            offset: pagination_offset
+          ).response
+        end
+
+        def scoped(relation)
+          if through_relation_klass
+            relation = relation.joins(through_relation_name)
+          end
+
+          relation
+        end
+
+        def raise_unless_primary_instance_exists
+          return unless subcollection?
+
+          klass = request_path_parts["primary_collection_name"].singularize.camelize.safe_constantize
+          klass.find(request_path_parts["primary_collection_id"].to_i)
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v1/sources_controller.rb
+++ b/spec/dummy/app/controllers/api/v1/sources_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class SourcesController < ApplicationController
+      include Api::V1::Mixins::IndexMixin
+    end
+  end
+end

--- a/spec/dummy/app/controllers/api/v1x0.rb
+++ b/spec/dummy/app/controllers/api/v1x0.rb
@@ -53,5 +53,6 @@ module Api
     end
 
     class GraphqlController < Api::V1::GraphqlController; end
+    class SourcesController < Api::V1::SourcesController; end
   end
 end

--- a/spec/dummy/config/routes.rb
+++ b/spec/dummy/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       resources :authentications, :only => [:create]
       resources :vms, :only => [:index, :show]
       resources :persons, :only => [:index, :create, :show, :update]
+      resources :sources, :only => [:index]
       resources :extras, :only => [:index]
     end
 

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -1,0 +1,43 @@
+RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
+  let(:external_tenant) { rand(1000).to_s }
+  let(:tenant)          { Tenant.create!(:name => "default", :external_tenant => external_tenant) }
+  let(:source_type)     { SourceType.create(:name => "rhex", :product_name => "RedHat Virtualization", :vendor => "redhat") }
+
+  def create_source(attrs = {})
+    Source.create!(attrs.merge(:tenant => tenant, :source_type => source_type))
+  end
+
+  def expect_success(query, *results)
+    get(URI.escape("/api/v1.0/sources?#{query}"))
+
+    expect(response).to(
+      have_attributes(
+        :parsed_body => a_hash_including("data" => results.collect { |i| a_hash_including("id" => i.id) }),
+        :status      => 200
+      )
+    )
+  end
+
+  context "case insensitive strings" do
+    let!(:source_1) { create_source(:name => "source_a")  }
+    let!(:source_2) { create_source(:name => "Source_A")  }
+    let!(:source_3) { create_source(:name => "source_b")  }
+    let!(:source_4) { create_source(:name => "Source_B")  }
+    let!(:source_5) { create_source(:name => "%source_d") }
+    let!(:source_6) { create_source(:name => "%Source_D") }
+    let!(:source_7) { create_source(:name => "Source_f%") }
+    let!(:source_8) { create_source(:name => "Source_F%") }
+
+    it("key:eq_i single")        { expect_success("filter[name][eq_i]=#{source_1.name}", source_1, source_2) }
+    it("key:eq_i array")         { expect_success("filter[name][eq_i][]=#{source_1.name}&filter[name][eq_i][]=#{source_3.name}", source_1, source_2, source_3, source_4) }
+
+    it("key:contains_i single")  { expect_success("filter[name][contains_i]=a", source_1, source_2) }
+    it("key:contains_i array")   { expect_success("filter[name][contains_i][]=s&filter[name][contains_i][]=a", source_1, source_2) }
+
+    it("key:starts_with_i")      { expect_success("filter[name][starts_with_i]=s", source_1, source_2, source_3, source_4, source_7, source_8) }
+    it("key:ends_with_i")        { expect_success("filter[name][ends_with_i]=b", source_3, source_4) }
+
+    it("key:starts_with_i %")    { expect_success("filter[name][starts_with_i]=%s", source_5, source_6) }
+    it("key:ends_with_i %")      { expect_success("filter[name][ends_with_i]=f%", source_7, source_8) }
+  end
+end


### PR DESCRIPTION
Adding support for case insensitive searches.

Approach taken here to support the case insensitive operators for the filter parameter in addition to the current string operators.

So adding support for:

  - starts_with_i
  - ends_with_i
  - contains_i
  - eq_i

This works with both REST API as well as GraphQL