### PR TITLE
[WIP] Use indexed arrays in request for filtering

### DIFF
--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -839,7 +839,7 @@
       "ID": {
         "type": "string",
         "description": "ID of the resource",
-        "pattern": "/^\\d+$/",
+        "pattern": "^\\d+$",
         "readOnly": true
       },
       "OrderParameters": {

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -39,5 +39,7 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
 
     it("key:starts_with_i %")    { expect_success("filter[name][starts_with_i]=%s", source_5, source_6) }
     it("key:ends_with_i %")      { expect_success("filter[name][ends_with_i]=f%", source_7, source_8) }
+
+    it("key:eq array") { expect_success("filter[id][]=#{source_7.id}&filter[id][]=#{source_8.id}", source_7, source_8) }
   end
 end

--- a/spec/requests/api/v1.0/filter_spec.rb
+++ b/spec/requests/api/v1.0/filter_spec.rb
@@ -28,11 +28,13 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     let!(:source_7) { create_source(:name => "Source_f%") }
     let!(:source_8) { create_source(:name => "Source_F%") }
 
-    it("key:eq_i single")        { expect_success("filter[name][eq_i]=#{source_1.name}", source_1, source_2) }
-    it("key:eq_i array")         { expect_success("filter[name][eq_i][]=#{source_1.name}&filter[name][eq_i][]=#{source_3.name}", source_1, source_2, source_3, source_4) }
+    it("key:eq_i single") { expect_success("filter[name][eq_i]=#{source_1.name}", source_1, source_2) }
+    it("key:eq_i array")  { expect_success("filter[name][eq_i][]=#{source_1.name}&filter[name][eq_i][]=#{source_3.name}", source_1, source_2, source_3, source_4) }
+    it("key:eq_i array with explicit indexes") { expect_success("filter[name][eq_i][0]=#{source_1.name}&filter[name][eq_i][1]=#{source_3.name}", source_1, source_2, source_3, source_4) }
 
     it("key:contains_i single")  { expect_success("filter[name][contains_i]=a", source_1, source_2) }
     it("key:contains_i array")   { expect_success("filter[name][contains_i][]=s&filter[name][contains_i][]=a", source_1, source_2) }
+    it("key:contains_i array with explicit indexes") { expect_success("filter[name][contains_i][0]=s&filter[name][contains_i][1]=a", source_1, source_2) }
 
     it("key:starts_with_i")      { expect_success("filter[name][starts_with_i]=s", source_1, source_2, source_3, source_4, source_7, source_8) }
     it("key:ends_with_i")        { expect_success("filter[name][ends_with_i]=b", source_3, source_4) }
@@ -41,5 +43,9 @@ RSpec.describe("::ManageIQ::API::Common::Filter", :type => :request) do
     it("key:ends_with_i %")      { expect_success("filter[name][ends_with_i]=f%", source_7, source_8) }
 
     it("key:eq array") { expect_success("filter[id][]=#{source_7.id}&filter[id][]=#{source_8.id}", source_7, source_8) }
+    it("key:eq array with explicit indexes") { expect_success("filter[id][0]=#{source_7.id}&filter[id][1]=#{source_8.id}", source_7, source_8) }
+
+    it("key:eq array with explicit eq comparator") { expect_success("filter[id][eq][]=#{source_7.id}&filter[id][eq][]=#{source_8.id}", source_7, source_8) }
+    it("key:eq array with explicit indexes explicit eq comparator") { expect_success("filter[id][eq][0]=#{source_7.id}&filter[id][eq][1]=#{source_8.id}", source_7, source_8) }
   end
 end


### PR DESCRIPTION
there is issue in handling indexed arrays in requests:

`/api/vms/filter[id][0]=2&filter[id][1]=44`
`/api/vms/filter[id][eq][0]=2&filter[id][eq][1]=44`
`...`

because in rails servers , there is  in `params`:  ( array is transformed to the hash as expected):
`{'0' => '1', '1' => '44'}`

I know that according to documentation we are not using this form but this exactly uses `Typhoeus   (EasyFactory) gem` and `Typhoeus gem ` is used in **our generated ruby Topological/Sources clients.**

Fix convert **such hashes** (`{'0' => '1', '1' => '44'}`) to arrays ['1', '44'] when **such hashes**  are present in params.



#### Testing scripts with for ruby Topological and RestClient(uses query: `filter[id][][]=1&filter[id][]=a`)

```ruby
TopologicalInventoryApiClient.configure { |config| config.scheme = "http"; config.host = "localhost:3000" }
 


# TopologicalInventoryApiClient

api_client = TopologicalInventoryApiClient::ApiClient.new
tap = TopologicalInventoryApiClient::DefaultApi.new(api_client)
ih = {'x-rh-identity' => Base64.strict_encode64(JSON.dump('identity' => { 'account_number' => 'XXX' }))}
api_client.default_headers.merge!(ih)

tap.list_vms({:filter => {:id =>[1,2,3]}}) 
# ^^^ This was throwing an error(without this fix) and it produces query:
# /api/vms/filter[id][0]=1&filter[id][1]=2&filter[id][1]=3


# RESTCLIENT
require 'rest-client'

tph = {:host => 'localhost', :port => 3000, :path => '/api/topological-inventory/v1.0/vms',  :query => {:filter => { :id => [1,2,3]} }.to_query}
  
uri = URI::HTTP.build(tph).to_s

ih = {'x-rh-identity' => Base64.strict_encode64(JSON.dump('identity' => { 'account_number' => 'XXX' }))}
   
RestClient::Request.execute(:method => :get, :url => uri.to_s, :headers => ih)
# this produces query which we can handle:
/api/vms/filter[id][]=1&filter[id][]=2&filter[id][]=3
```

so this fix allows us to use generated clients for batch query.

what do you think about this fix ? @abellotti @bdunne @slemrmartin 


thanks!










