### PR TITLE
Fix nested attributes

### DIFF
--- a/lib/manageiq/api/common/open_api/docs/object_definition.rb
+++ b/lib/manageiq/api/common/open_api/docs/object_definition.rb
@@ -5,7 +5,7 @@ module ManageIQ
         class Docs
           class ObjectDefinition < Hash
             def all_attributes
-              properties.keys
+              properties.map { |key, val| all_attributes_recursive(key, val) }
             end
 
             def read_only_attributes
@@ -18,6 +18,18 @@ module ManageIQ
 
             def properties
               self["properties"]
+            end
+
+            private
+
+            def all_attributes_recursive(key, value)
+              if value["properties"]
+                {
+                  key => value["properties"].map { |k, v| all_attributes_recursive(k, v) }
+                }
+              else
+                key
+              end
             end
           end
         end

--- a/spec/dummy/public/doc/openapi-3-v1.0.0.json
+++ b/spec/dummy/public/doc/openapi-3-v1.0.0.json
@@ -986,6 +986,15 @@
           },
           "zip": {
             "type": "string"
+          },
+          "nested": {
+            "additionalProperties": false,
+            "type": "object",
+            "properties": {
+              "props": {
+                "type": "string"
+              }
+            }
           }
         }
       },

--- a/spec/requests/params_spec.rb
+++ b/spec/requests/params_spec.rb
@@ -47,5 +47,11 @@ RSpec.describe "ManageIQ::API::Common::ApplicationController Parameters", :type 
       patch("/api/v1.0/persons/10", :headers => headers, :params => body)
       expect(response.status).to eq(400)
     end
+
+    it "valid nested parameters" do
+      body = { 'name' => 'fred', 'zip' => '07825', 'age' => 45, 'nested' => {'props' => 'abcd'} }
+      patch("/api/v1.0/persons/10", :headers => headers, :params => body)
+      expect(response.status).to eq(200)
+    end
   end
 end


### PR DESCRIPTION
The OpenApi::Docs::ObjectDefinition.all_attributes method was only
returning top level attribute names without considering that some of
those attributes might be nested objects.

This was causing the body_params.permit! to fail because it found nested
parameters.

https://github.com/ManageIQ/sources-api/issues/110