### PR TITLE
Changed scope for sharing/unsharing to be account based

### DIFF
--- a/lib/manageiq/api/common/rbac/query_shared_resource.rb
+++ b/lib/manageiq/api/common/rbac/query_shared_resource.rb
@@ -13,7 +13,7 @@ module ManageIQ
             @resource_id = options[:resource_id]
             @resource_name = options[:resource_name]
             @share_info = []
-            @roles = RBAC::Roles.new("#{@app_name}-#{@resource_name}-#{@resource_id}")
+            @roles = RBAC::Roles.new("#{@app_name}-#{@resource_name}-#{@resource_id}", 'account')
           end
 
           def process

--- a/lib/manageiq/api/common/rbac/share_resource.rb
+++ b/lib/manageiq/api/common/rbac/share_resource.rb
@@ -17,7 +17,7 @@ module ManageIQ
 
           def process
             validate_groups
-            @roles = RBAC::Roles.new("#{@app_name}-#{@resource_name}-")
+            @roles = RBAC::Roles.new("#{@app_name}-#{@resource_name}-", 'account')
             @group_uuids.each { |uuid| manage_roles_for_group(uuid) }
             self
           end

--- a/spec/lib/manageiq/api/common/rbac/query_shared_resource_spec.rb
+++ b/spec/lib/manageiq/api/common/rbac/query_shared_resource_spec.rb
@@ -7,7 +7,7 @@ describe ManageIQ::API::Common::RBAC::QuerySharedResource do
       :resource_id   => resource_id1,
       :resource_name => resource }
   end
-  let(:pagination_options) { { :limit => 500, :name => "catalog-portfolios-#{resource_id1}", :scope => "principal" } }
+  let(:pagination_options) { { :limit => 500, :name => "catalog-portfolios-#{resource_id1}", :scope => "account" } }
 
   let(:access1) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:read", :resource_definitions => [resource_def1]) }
   let(:access2) { instance_double(RBACApiClient::Access, :permission => "#{app_name}:#{resource}:write", :resource_definitions => [resource_def1]) }

--- a/spec/lib/manageiq/api/common/rbac/share_resource_spec.rb
+++ b/spec/lib/manageiq/api/common/rbac/share_resource_spec.rb
@@ -9,7 +9,7 @@ describe ManageIQ::API::Common::RBAC::ShareResource do
       :resource_name => resource }
   end
   let(:subject) { described_class.new(options) }
-  let(:pagination_options) { { :limit => 500, :name => "catalog-portfolios-", :scope => "principal" } }
+  let(:pagination_options) { { :limit => 500, :name => "catalog-portfolios-", :scope => "account" } }
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)

--- a/spec/lib/manageiq/api/common/rbac/unshare_resource_spec.rb
+++ b/spec/lib/manageiq/api/common/rbac/unshare_resource_spec.rb
@@ -8,7 +8,7 @@ describe ManageIQ::API::Common::RBAC::UnshareResource do
       :resource_name => "portfolios" }
   end
   let(:subject) { described_class.new(options) }
-  let(:pagination_options) { { :limit => 500, :name => "catalog-portfolios-", :scope => "principal" } }
+  let(:pagination_options) { { :limit => 500, :name => "catalog-portfolios-", :scope => "account" } }
 
   before do
     allow(rs_class).to receive(:call).with(RBACApiClient::GroupApi).and_yield(api_instance)


### PR DESCRIPTION
When the RBAC code was created in common gem it  was from the Approval source code
which uses the default scope to be principal (currently logged in user).
For Catalogs Sharing/Unsharing/Query feature we need to be in tenant
scope. This PR passes in the proper scope