### PR TITLE
Split model and controller

### DIFF
--- a/lib/insights/api/common/application_controller_mixins/api_doc.rb
+++ b/lib/insights/api/common/application_controller_mixins/api_doc.rb
@@ -25,7 +25,7 @@ module Insights
             end
 
             def api_doc_definition
-              @api_doc_definition ||= api_doc.definitions[model.name]
+              @api_doc_definition ||= api_doc.definitions[name.split("::").last[0..-11].singularize]
             end
 
             def api_version

--- a/lib/insights/api/common/open_api/generator.rb
+++ b/lib/insights/api/common/open_api/generator.rb
@@ -419,7 +419,7 @@ module Insights
             new_content = openapi_contents.dup
             new_content["paths"] = build_paths.sort.to_h
             new_content["components"] ||= {}
-            new_content["components"]["schemas"]    = schemas.sort.each_with_object({})    { |(name, val), h| h[name] = val || openapi_contents["components"]["schemas"][name]    || {} }
+            new_content["components"]["schemas"]    = schemas.merge(schema_overrides).sort.each_with_object({}) { |(name, val), h| h[name] = val || openapi_contents["components"]["schemas"][name] || {} }
             new_content["components"]["parameters"] = parameters.sort.each_with_object({}) { |(name, val), h| h[name] = val || openapi_contents["components"]["parameters"][name] || {} }
             File.write(openapi_file, JSON.pretty_generate(new_content) + "\n")
             Insights::API::Common::GraphQL::Generator.generate(api_version, new_content) if graphql
@@ -514,6 +514,10 @@ module Insights
           end
 
           def handle_custom_route_action(_route_action, _verb, _primary_collection)
+          end
+
+          def schema_overrides
+            {}
           end
         end
       end

--- a/lib/insights/api/common/open_api/generator.rb
+++ b/lib/insights/api/common/open_api/generator.rb
@@ -438,6 +438,8 @@ module Insights
                 [key, openapi_schema_properties_value(klass_name, model, key, value)]
               end
             end.compact.sort.to_h
+          rescue NameError
+            openapi_contents["components"]["schemas"][klass_name]["properties"]
           end
 
           def generator_blacklist_attributes

--- a/lib/insights/api/common/open_api/generator.rb
+++ b/lib/insights/api/common/open_api/generator.rb
@@ -474,10 +474,12 @@ module Insights
 
           def build_paths
             applicable_rails_routes.each_with_object({}) do |route, expected_paths|
-              without_format = route.path.split("(.:format)").first
-              sub_path = without_format.split(base_path).last.sub(/:[_a-z]*id/, "{id}")
-              klass_name = route.controller.split("/").last.camelize.singularize
-              verb = route.verb.downcase
+              without_format     = route.path.split("(.:format)").first
+              sub_path           = without_format.split(base_path).last.sub(/:[_a-z]*id/, "{id}")
+              route_destination  = route.controller.split("/").last.camelize
+              controller         = "Api::V#{api_version.sub(".", "x")}::#{route_destination}Controller".safe_constantize
+              klass_name         = controller.try(:presentation_name) || route_destination.singularize
+              verb               = route.verb.downcase
               primary_collection = sub_path.split("/")[1].camelize.singularize
 
               expected_paths[sub_path] ||= {}

--- a/lib/insights/api/common/open_api/serializer.rb
+++ b/lib/insights/api/common/open_api/serializer.rb
@@ -9,7 +9,8 @@ module Insights
             encryption_filtered = previous.except(*encrypted_columns_set)
             return encryption_filtered unless arg.key?(:prefixes)
             version = api_version_from_prefix(arg[:prefixes].first)
-            schema  = ::Insights::API::Common::OpenApi::Docs.instance[version].definitions[self.class.name]
+            presentation_name = self.class.try(:presentation_name) || self.class.name
+            schema  = ::Insights::API::Common::OpenApi::Docs.instance[version].definitions[presentation_name]
             attrs   = encryption_filtered.slice(*schema["properties"].keys)
             schema["properties"].keys.each do |name|
               next if attrs[name].nil?


### PR DESCRIPTION
For https://github.com/ManageIQ/topological_inventory-api/pull/259

- Loosen the ties between controller and model
- Look up the API doc definition based on the controller rather than the model
- Allow records to be serialized using a schema other than the model name
- Allow for API schemas that aren't backed by a model
